### PR TITLE
fix(cmd/xliff): update markdown-translation version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apidevtools/swagger-parser": "^10.1.0",
         "@aws-sdk/client-s3": "^3.369.0",
         "@diplodoc/client": "^1.0.2",
-        "@diplodoc/markdown-translation": "^1.0.1",
+        "@diplodoc/markdown-translation": "^1.0.2",
         "@diplodoc/mermaid-extension": "^1.1.3",
         "@diplodoc/openapi-extension": "^1.4.4",
         "@diplodoc/transform": "^4.3.0",
@@ -1764,12 +1764,12 @@
       }
     },
     "node_modules/@diplodoc/markdown-it-markdown-renderer": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.15.5.tgz",
-      "integrity": "sha512-DlbANcf17nD/moMs8dKO4ZUOLZ8qiBYnPDPj8U0IPTG3zWAe8fppvWh0eX+4e1mSG89R4oZgmJgpkVNxcloAfg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.15.6.tgz",
+      "integrity": "sha512-9YgPHeMv/yOg1ctfnA3wUtsVFDyyURyvK5ZAnHub1+bA4T0BR9ka2k2SPiTfIXwoW2CrdNHfMSuMZy+1PCd4CQ==",
       "dependencies": {
         "@diplodoc/markdown-it-custom-renderer": "^0.1.2",
-        "@diplodoc/transform": "^4.2.1",
+        "@diplodoc/transform": "^4.7.1",
         "markdown-it-sup": "^1.0.0"
       },
       "engines": {
@@ -1781,15 +1781,15 @@
       }
     },
     "node_modules/@diplodoc/markdown-translation": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-1.0.1.tgz",
-      "integrity": "sha512-X/66KbAUQJo81x4LCkGn6MVRrAiFjAwrqwF2iLqSvAus0o+ZciEg9v1QN8NYaBi6UYsf9A2pQwAkud6wUZF9Yg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-1.0.2.tgz",
+      "integrity": "sha512-jXmHZjYIico36IGAna5IXY4mlKFHAAEGKY8mXsr955ogBbn+I/jIzNDIjUKZ8Qxdoztn8FCmaoYKM1LMIVd7Nw==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "^4.1.0",
         "@diplodoc/markdown-it-custom-renderer": "^0.1.2",
-        "@diplodoc/markdown-it-markdown-renderer": "^0.15.5",
-        "@diplodoc/sentenizer": "^0.0.1",
-        "@diplodoc/transform": "^4.3.1",
+        "@diplodoc/markdown-it-markdown-renderer": "^0.15.6",
+        "@diplodoc/sentenizer": "^0.0.2",
+        "@diplodoc/transform": "^4.7.1",
         "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",
         "cheerio": "^1.0.0-rc.12",
         "domhandler": "^5.0.3",
@@ -1864,9 +1864,9 @@
       }
     },
     "node_modules/@diplodoc/sentenizer": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/sentenizer/-/sentenizer-0.0.1.tgz",
-      "integrity": "sha512-sXtIEjwx8/Hdb68sbIjtauuSuqF02uekctaaqHoeE54BjSjwzPDPvI/q1lQ1NK6oF5/2g21ncHyWjdYJbasvww==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/sentenizer/-/sentenizer-0.0.2.tgz",
+      "integrity": "sha512-YXaLCJ5Ootl38/osUKfiEDxyjuS6MB5swZeE4UrQ0WRVVC2kTXK+qMG+xWT1mIIsXYMu6TILwTKHv8ZqkCKEFQ==",
       "dependencies": {
         "@types/ramda": "^0.28.13",
         "ramda": "^0.28.0"
@@ -1886,9 +1886,9 @@
       }
     },
     "node_modules/@diplodoc/transform": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/transform/-/transform-4.3.1.tgz",
-      "integrity": "sha512-igZJRps00wm8t3OtfnT//vA1HE2TCq5vh1XmU9DgeodxhqcA6Iwfhkk9sl92NhrH2sULmzateM5s6GQXzoFiWQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@diplodoc/transform/-/transform-4.7.1.tgz",
+      "integrity": "sha512-PkTVrRcGgbwaUpJ+9dYesEGzIdEuGw80PUbBV4p4reAGRZRwo/YuoJupwmepfWUALA3kLbobcN6t5OxkDbp+JA==",
       "dependencies": {
         "@diplodoc/tabs-extension": "2.0.12",
         "chalk": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@apidevtools/swagger-parser": "^10.1.0",
     "@aws-sdk/client-s3": "^3.369.0",
     "@diplodoc/client": "^1.0.2",
-    "@diplodoc/markdown-translation": "^1.0.1",
+    "@diplodoc/markdown-translation": "^1.0.2",
     "@diplodoc/mermaid-extension": "^1.1.3",
     "@diplodoc/openapi-extension": "^1.4.4",
     "@diplodoc/transform": "^4.3.0",


### PR DESCRIPTION
- handle abbreviations that stick to non alphabet symbols
- handle liquid syntax inside inline code
- handle new note_content_open/close tokens