### PR TITLE
feat: support __navigation var to set navigation section

### DIFF
--- a/src/services/tocs.ts
+++ b/src/services/tocs.ts
@@ -46,6 +46,12 @@ async function init(tocFilePaths: string[]) {
 
         await addNavigation(path);
     }
+
+    for (const path of tocFilePaths) {
+        logger.proc(path);
+
+        await prepareNavigationSection(path);
+    }
 }
 
 async function add(path: string) {
@@ -144,6 +150,26 @@ async function addNavigation(path: string) {
 
     const pathToDir = dirname(path);
     prepareNavigationPaths(parsedToc, pathToDir);
+}
+
+async function prepareNavigationSection(path: string) {
+    const {vars} = ArgvService.getConfig();
+
+    const parsedToc = getForPath(path);
+
+    if (!parsedToc) {
+        return;
+    }
+
+    const pathToDir = dirname(path);
+    const combinedVars = {
+        ...PresetService.get(pathToDir),
+        ...vars,
+    };
+
+    if (combinedVars.__navigation) {
+        parsedToc.navigation = combinedVars.__navigation;
+    }
 }
 
 async function processTocItems(


### PR DESCRIPTION
Supported `__navigation` variable, which can be set in presets (presets.yaml file) to set navigation for documentation

Example of presets.yaml:
```
logo: &logo
  text: 'Example'

external:
  __navigation:
    logo: *logo
    header:
      rightItems:
        - type: 'link'
          text: 'Lorem ipsum 1'
          url: 'https://example.com'
        - type: controls

internal:
  __navigation:
    logo: *logo
    header:
      rightItems:
        - type: 'link'
          text: 'Lorem ipsum 2'
          url: 'https://example.com'
        - type: controls
       
```