### PR TITLE
Apply some rudimentary workarounds for outstanding TS issues

### DIFF
--- a/src/@types/nodeError.d.ts
+++ b/src/@types/nodeError.d.ts
@@ -1,0 +1,6 @@
+declare interface Error {
+    name: string;
+    message: string;
+    stack?: string;
+    code?: number | string;
+}

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -1,10 +1,10 @@
-import type {IProgram} from '~/program';
+import type {IProgram, ProgramArgs} from '~/program';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
 import {Help} from 'commander';
 import log from '@diplodoc/transform/lib/log';
 
-import {BaseProgram} from '~/program/base';
+import {BaseHooks, BaseProgram} from '~/program/base';
 import {Command} from '~/config';
 import {build} from '~/cmd';
 
@@ -15,6 +15,10 @@ export type BuildArgs = {};
 export type BuildConfig = {};
 
 const parser = yargs
+    // FIXME: Since we're adding more arguments to the mix with
+    // `argvValidator` (see src/cmd/build/index.ts#L170), the type safety just completely breaks here
+    // (which makes sense, because stuff we do is absurdly unsound)
+    // @ts-expect-error
     .command(build)
     .option('config', {
         alias: 'c',
@@ -34,12 +38,12 @@ const parser = yargs
         type: 'boolean',
     })
     .group(['config', 'strict', 'quiet', 'help', 'version'], 'Common options:')
-    .version(typeof VERSION !== 'undefined' ? VERSION : '')
+    .version(typeof VERSION === 'undefined' ? '' : VERSION)
     .help();
 
 export class Build
     // eslint-disable-next-line new-cap
-    extends BaseProgram<BuildConfig, BuildArgs>(command, {
+    extends BaseProgram<BuildConfig, ProgramArgs>(command, {
         config: {
             // scope: 'build',
             defaults: () => ({}),
@@ -47,7 +51,8 @@ export class Build
         command: {
             isDefault: true,
         },
-        hooks: () => {},
+        // FIXME: This is a temporary workaround
+        hooks: (() => {}) as unknown as BaseHooks<BuildConfig, ProgramArgs>,
     })
     implements IProgram<BuildArgs>
 {
@@ -62,6 +67,9 @@ export class Build
 
         this.command.createHelp = function () {
             const help = new Help();
+            // FIXME: This is not supposed to work, since `parser.getHelp` returns a Promise
+            // I'm not building a sync bridge for this right now
+            // @ts-expect-error
             help.formatHelp = () => parser.getHelp();
             return help;
         };

--- a/src/commands/publish/index.spec.ts
+++ b/src/commands/publish/index.spec.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from 'vitest';
+// @ts-expect-error FIXME
 import {runPublish as run, testConfig as test} from './__tests__';
 
 describe('Publish command', () => {

--- a/src/commands/translate/__tests__/index.ts
+++ b/src/commands/translate/__tests__/index.ts
@@ -63,7 +63,7 @@ export function testConfig<Config = TranslateConfig>(defaultArgs: string) {
             });
 
             if (result instanceof Error || typeof result === 'string') {
-                const message = result.message || result;
+                const message = result instanceof Error ? result.message : result;
                 await expect(async () => runTranslate(defaultArgs + ' ' + args)).rejects.toThrow(
                     message,
                 );

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -72,6 +72,8 @@ export function args(command: Command | null) {
     let args: string[] | undefined;
 
     while (command) {
+        // FIXME: This is probably broken
+        // @ts-expect-error
         args = command.rawArgs || args;
         command = command.parent;
     }

--- a/src/program/index.ts
+++ b/src/program/index.ts
@@ -42,13 +42,13 @@ export class Program
             }),
         },
     })
-    implements IProgram
+    implements IProgram<ProgramArgs>
 {
     readonly command: Command = new Command(NAME)
         .helpOption(true)
         .allowUnknownOption(false)
         .version(
-            typeof VERSION !== 'undefined' ? VERSION : '',
+            typeof VERSION === 'undefined' ? '' : VERSION,
             '--version',
             'Output the version number',
         )
@@ -75,7 +75,7 @@ export class Program
         .helpOption(false)
         .allowUnknownOption(true);
 
-    private readonly modules: ICallable[] = [this.build, this.publish, this.translate];
+    private readonly modules: ICallable<ProgramArgs>[] = [this.build, this.publish, this.translate];
 
     async init(argv: string[]) {
         const args = this.parser.parse(argv).opts() as ProgramArgs;

--- a/src/program/types.ts
+++ b/src/program/types.ts
@@ -5,8 +5,8 @@ import type {Logger} from '~/logger';
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 type Hooks = Record<string, Hook<any, any> | HookMap<any>>;
 
-export interface ICallable {
-    apply(program?: IProgram): void;
+export interface ICallable<Args extends Hash = Hash> {
+    apply(program?: IProgram<Args>): void;
 }
 
 /**

--- a/src/resolvers/lintPage.ts
+++ b/src/resolvers/lintPage.ts
@@ -1,6 +1,6 @@
 import {dirname, relative, resolve} from 'path';
 import {load} from 'js-yaml';
-import log from '@diplodoc/transform/lib/log';
+import log, {LogLevels} from '@diplodoc/transform/lib/log';
 import {
     LintMarkdownFunctionOptions,
     PluginOptions,
@@ -76,15 +76,17 @@ function YamlFileLinter(content: string, lintOptions: FileTransformOptions): voi
         defaultLevel: log.LogLevels.ERROR,
     });
 
-    const contentLinks = findAllValuesByKeys(load(content), LINK_KEYS);
+    const contentLinks = findAllValuesByKeys(load(content) as object, LINK_KEYS);
     const localLinks = contentLinks.filter(
         (link) => getLinksWithExtension(link) && isLocalUrl(link),
     );
 
+    const loggerForLogLevel = logLevel === LogLevels.DISABLED ? () => undefined : log[logLevel];
+
     return localLinks.forEach(
         (link) =>
             checkPathExists(link, currentFilePath) ||
-            log[logLevel](`Link is unreachable: ${bold(link)} in ${bold(currentFilePath)}`),
+            loggerForLogLevel(`Link is unreachable: ${bold(link)} in ${bold(currentFilePath)}`),
     );
 }
 

--- a/src/resolvers/md2html.ts
+++ b/src/resolvers/md2html.ts
@@ -114,10 +114,13 @@ export async function resolveMd2HTML(options: ResolverOptions): Promise<DocInner
     const {outputPath, inputPath, deep, deepBase} = options;
     const props = await getFileProps(options);
 
+    // FIXME: Whatever we're doing with app props in CLI is pretty unsound
+    // @ts-expect-error
     const outputFileContent = generateStaticMarkup(props, deepBase, deep);
     writeFileSync(outputPath, outputFileContent);
     logger.info(inputPath, PROCESSING_FINISHED);
 
+    // @ts-expect-error
     return props;
 }
 
@@ -170,11 +173,18 @@ function YamlFileTransformer(content: string, transformOptions: FileTransformOpt
             if (isString(link) && getLinksWithContentExtersion(link)) {
                 return link.replace(/.(md|yaml)$/gmu, '.html');
             }
+
+            return link;
         });
 
+        // FIXME: This is unsound, since `lang` does not exist on FileTransformOptions
+        // I'll leave this here for the sake of not breaking stuff
+        // @ts-expect-error
         const {path, lang} = transformOptions;
         const transformFn: Function = FileTransformer['.md'];
 
+        // FIXME: Whatever we're doing here with prop transformations, it seems quite unsound
+        // @ts-expect-error
         data = preprocess(data, {lang}, (lang, content) => {
             const {result} = transformFn(content, {path});
             return result?.html;
@@ -221,7 +231,7 @@ function MdFileTransformer(content: string, transformOptions: FileTransformOptio
 
     return transform(content, {
         ...options,
-        plugins: plugins as MarkdownItPluginCb<unknown>[],
+        plugins: plugins as MarkdownItPluginCb[],
         vars,
         root,
         path,

--- a/src/services/contributors.ts
+++ b/src/services/contributors.ts
@@ -71,7 +71,7 @@ async function getContributorsForNestedFiles(
             try {
                 contentIncludeFile = await readFile(relativeIncludeFilePath, 'utf8');
             } catch (err) {
-                if (err.code === 'ENOENT') {
+                if (err instanceof Error && err.code === 'ENOENT') {
                     continue;
                 }
                 throw err;
@@ -135,14 +135,18 @@ async function getFileIncludes(
     );
     for (const relativeIncludeFilePath of relativeIncludeFilePaths.values()) {
         const relativeFilePath = relativeIncludeFilePath.substring(inputFolderPathLength + 1);
-        if (results.has(relativeFilePath)) continue;
+
+        if (results.has(relativeFilePath)) {
+            continue;
+        }
+
         results.add(relativeFilePath);
 
         let contentIncludeFile: string;
         try {
             contentIncludeFile = await readFile(relativeIncludeFilePath, 'utf8');
         } catch (err) {
-            if (err.code === 'ENOENT') {
+            if (err instanceof Error && err.code === 'ENOENT') {
                 continue;
             }
             throw err;

--- a/src/services/includers/batteries/generic.ts
+++ b/src/services/includers/batteries/generic.ts
@@ -83,7 +83,9 @@ async function includerFunction(params: IncluderFunctionParams<Params>) {
 
         await writeFile(join(writePath, 'toc.yaml'), dump(toc));
     } catch (err) {
-        throw new GenericIncluderError(err.toString(), tocPath);
+        const message = err instanceof Error ? err.message : String(err);
+
+        throw new GenericIncluderError(message, tocPath);
     }
 }
 

--- a/src/services/includers/batteries/unarchive.ts
+++ b/src/services/includers/batteries/unarchive.ts
@@ -92,7 +92,9 @@ async function includerFunction(params: IncluderFunctionParams<Params>) {
     try {
         await pipeline(contentPath, writePath);
     } catch (err) {
-        throw new UnarchiveIncluderError(err.toString(), tocPath);
+        const message = err instanceof Error ? err.message : String(err);
+
+        throw new UnarchiveIncluderError(message, tocPath);
     }
 }
 

--- a/src/steps/processPages.ts
+++ b/src/steps/processPages.ts
@@ -175,6 +175,8 @@ async function saveSinglePages() {
                 const singlePageFn = join(tocDir, SINGLE_PAGE_FILENAME);
                 const singlePageDataFn = join(tocDir, SINGLE_PAGE_DATA_FILENAME);
                 const singlePageContent = generateStaticMarkup(
+                    // FIXME: Whatever we do here with page props is pretty unsound
+                    // @ts-expect-error
                     pageData,
                     toc?.root?.deepBase || toc?.deepBase || 0,
                 );

--- a/src/utils/markup.ts
+++ b/src/utils/markup.ts
@@ -174,7 +174,7 @@ export function replaceDoubleToSingleQuotes(str: string): string {
     return str.replace(/"/g, "'");
 }
 
-export function findAllValuesByKeys(obj, keysToFind: string[]) {
+export function findAllValuesByKeys(obj: object, keysToFind: string[]): string[] {
     return flatMapDeep(obj, (value: string | string[], key: string) => {
         if (
             keysToFind?.includes(key) &&
@@ -192,14 +192,16 @@ export function findAllValuesByKeys(obj, keysToFind: string[]) {
 }
 
 export function modifyValuesByKeys(
-    originalObj,
+    originalObj: object,
     keysToFind: string[],
     modifyFn: (value: string) => string,
 ) {
-    function customizer(value, key) {
-        if (keysToFind?.includes(key) && isString(value)) {
+    function customizer(value: unknown, key: number | string | undefined) {
+        if (typeof key === 'string' && keysToFind?.includes(key) && isString(value)) {
             return modifyFn(value);
         }
+
+        return undefined;
     }
 
     // Clone the object deeply with a customizer function that modifies matching keys

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,7 +1,7 @@
 import {Arguments} from 'yargs';
 import {join, resolve} from 'path';
 import {readFileSync} from 'fs';
-import {load} from 'js-yaml';
+import {YAMLException, load} from 'js-yaml';
 import merge from 'lodash/merge';
 import log from '@diplodoc/transform/lib/log';
 import {LINT_CONFIG_FILENAME, REDIRECTS_FILENAME, YFM_CONFIG_FILENAME} from './constants';
@@ -95,7 +95,7 @@ export function argvValidator(argv: Arguments<Object>): Boolean {
         const content = readFileSync(resolve(pathToConfig), 'utf8');
         Object.assign(argv, load(content) || {});
     } catch (error) {
-        if (error.name === 'YAMLException') {
+        if (error instanceof YAMLException) {
             log.error(`Error to parse ${YFM_CONFIG_FILENAME}: ${error.message}`);
         }
     }
@@ -107,7 +107,7 @@ export function argvValidator(argv: Arguments<Object>): Boolean {
 
         lintConfig = load(content) || {};
     } catch (error) {
-        if (error.name === 'YAMLException') {
+        if (error instanceof YAMLException) {
             log.error(`Error to parse ${LINT_CONFIG_FILENAME}: ${error.message}`);
         }
     } finally {
@@ -127,11 +127,11 @@ export function argvValidator(argv: Arguments<Object>): Boolean {
 
         validateRedirects(redirects as RedirectsConfig, pathToRedirects);
     } catch (error) {
-        if (error.name === 'YAMLException') {
+        if (error instanceof YAMLException) {
             log.error(`Error to parse ${REDIRECTS_FILENAME}: ${error.message}`);
         }
 
-        if (error.code !== 'ENOENT') {
+        if (error instanceof Error && error.code !== 'ENOENT') {
             throw error;
         }
     }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es2019",
     "moduleResolution": "NodeNext",
+    "module": "NodeNext",
     "esModuleInterop": true,
     "paths": {
       "*": [
@@ -11,6 +12,7 @@
     "types": [
       "node",
       "jest"
-    ]
-  }
+    ],
+  },
+  "include": ["../src/@types"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": ["ES2019"],
     "target": "es6",
     "outDir": "build",
-    "module": "CommonJS",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "paths": {
       "~/*": ["./src/*"]
     }


### PR DESCRIPTION
I mostly made some basic changes like adding `// @ts-expect-error` magic comments for pieces of code that break type safety. This is aimed at restoring the possibility to use type checking as normal when developing new features.