### PR TITLE
fix: fixed localisation for notes block

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -263,6 +263,7 @@ export interface ResolverOptions {
     fileExtension: string;
     outputPath: string;
     outputBundlePath: string;
+    lang: string;
     metadata?: MetaDataOptions;
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

Fixed localisation for notes block: pass file language to notes pluging instead of always using yfm args.

Related issue: #890

