### PR TITLE
Pin cytoscape to 3.31.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6414,10 +6414,9 @@
       "peer": true
     },
     "node_modules/cytoscape": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.31.1.tgz",
-      "integrity": "sha512-Hx5Mtb1+hnmAKaZZ/7zL1Y5HTFYOjdDswZy/jD+1WINRU8KVi1B7+vlHdsTwY+VCFucTreoyu1RDzQJ9u0d2Hw==",
-      "license": "MIT",
+      "version": "3.31.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.31.2.tgz",
+      "integrity": "sha512-/eOXg2uGdMdpGlEes5Sf6zE+jUG+05f3htFNQIxLxduOH/SsaUZiPBfAwP1btVIVzsnhiNOdi+hvDRLYfMZjGw==",
       "engines": {
         "node": ">=0.10"
       }

--- a/package.json
+++ b/package.json
@@ -133,6 +133,9 @@
     "vitest-when": "^0.5.0",
     "walk-sync": "^3.0.0"
   },
+  "overrides": {
+    "cytoscape": "3.31.2"
+  },
   "engines": {
     "node": ">=18.*"
   }


### PR DESCRIPTION
Latest version of `cytoscape` breaks the installation of CLI: https://github.com/cytoscape/cytoscape.js/issues/3368#issuecomment-2839915605

This PR addresses that by pinning the version of `cytoscape`.