### PR TITLE
Fix: empty metadata in a file breaks the docs building

### DIFF
--- a/src/core/markdown/loader/mangle-frontmatter.ts
+++ b/src/core/markdown/loader/mangle-frontmatter.ts
@@ -12,7 +12,7 @@ export function mangleFrontMatter(this: LoaderContext, rawContent: string) {
 
     const [frontmatter, content, rawFrontmatter] = safeExtractFrontmatter.call(this, rawContent);
 
-    if (!rawFrontmatter) {
+    if (!frontmatter || !rawFrontmatter) {
         this.api.meta.set({});
         return rawContent;
     }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

The build fails with the error:
```
TypeError: Cannot read properties of null (reading 'metadata')
    at MetaService.add (/Users/vsesh/nebo-git/ui/apps/docs/node_modules/.pnpm/@diplodoc+cli@4.57.22_@types+markdown-it@13.0.9_markdown-it@13.0.2_react@18.3.1/node_modules/@diplodoc/cli/lib/meta/index.js:141:35)
    at MarkdownService.load (/Users/vsesh/nebo-git/ui/apps/docs/node_modules/.pnpm/@diplodoc+cli@4.57.22_@types+markdown-it@13.0.9_markdown-it@13.0.2_react@18.3.1/node_modules/@diplodoc/cli/lib/markdown/index.js:492:21)
    at async resolveToMd (/Users/vsesh/nebo-git/ui/apps/docs/node_modules/.pnpm/@diplodoc+cli@4.57.22_@types+markdown-it@13.0.9_markdown-it@13.0.2_react@18.3.1/node_modules/@diplodoc/cli/build/index.js:251320:22)
    at async concurrency (/Users/vsesh/nebo-git/ui/apps/docs/node_modules/.pnpm/@diplodoc+cli@4.57.22_@types+markdown-it@13.0.9_markdown-it@13.0.2_react@18.3.1/node_modules/@diplodoc/cli/build/index.js:251524:25)
    at async /Users/vsesh/nebo-git/ui/apps/docs/node_modules/.pnpm/p-map@4.0.0/node_modules/p-map/index.js:57:22
   ```
   
   If a document has empty metadata. Example:
   ```
   ---
   #  some comment
   ---
```

Related issue: #(issue number)

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
