### PR TITLE
Fix source to full path

### DIFF
--- a/src/commands/build/features/changelogs/index.ts
+++ b/src/commands/build/features/changelogs/index.ts
@@ -92,10 +92,7 @@ export class Changelogs {
                                 `__changes-${changesName}.json`,
                             );
 
-                            return run.write(
-                                changesPath,
-                                JSON.stringify(changes),
-                            );
+                            return run.write(changesPath, JSON.stringify(changes));
                         });
                     },
                 );

--- a/src/commands/build/features/changelogs/index.ts
+++ b/src/commands/build/features/changelogs/index.ts
@@ -78,6 +78,8 @@ export class Changelogs {
                         const filename = basename(path, extname(path));
                         const outputDir = dirname(join(run.output, path));
 
+                        changelogs[changelogs.length - 1].source = join(dirname(path), filename);
+
                         await pmap(changelogs, (changes, index) => {
                             const changesName = changelogName(
                                 filename,
@@ -92,10 +94,7 @@ export class Changelogs {
 
                             return run.write(
                                 changesPath,
-                                JSON.stringify({
-                                    ...changes,
-                                    source: filename,
-                                }),
+                                JSON.stringify(changes),
                             );
                         });
                     },


### PR DESCRIPTION
## Description

Now each changelog from one file has filename in field source. But we doesn't want link after each changelog, we want one link for one file. And need full pathname for correct link to doc