### PR TITLE
fix: rm no-translate directive, leave content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@diplodoc/client": "^3.6.3",
         "@diplodoc/liquid": "^1.3.1",
-        "@diplodoc/translation": "^1.7.15",
+        "@diplodoc/translation": "^1.7.17",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
         "csp-header": "^5.2.1",
@@ -1885,12 +1885,13 @@
       }
     },
     "node_modules/@diplodoc/translation": {
-      "version": "1.7.15",
-      "resolved": "https://registry.npmjs.org/@diplodoc/translation/-/translation-1.7.15.tgz",
-      "integrity": "sha512-BmjXhqRjakuDRj2aFqnpb78ufDOxoHi9/0yexvQKiBQlg68ONisLGTxVzpwkLfmMUpeOePwSz1iYIOAqK1e98g==",
+      "version": "1.7.17",
+      "resolved": "https://registry.npmjs.org/@diplodoc/translation/-/translation-1.7.17.tgz",
+      "integrity": "sha512-D5JfB5g1/+4VSIt7fRxQHoBGO5Q517bzja++ZM4VkOl9gWSdrJWJXRKdJdfkD7rA/ADFFDBIrchfTvVpqY44gQ==",
       "license": "MIT",
       "dependencies": {
         "@cospired/i18n-iso-languages": "^4.1.0",
+        "@diplodoc/directive": "^0.3.2",
         "@diplodoc/sentenizer": "^0.0.8",
         "@diplodoc/transform": "^4.10.0",
         "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@diplodoc/client": "^3.6.3",
     "@diplodoc/liquid": "^1.3.1",
-    "@diplodoc/translation": "^1.7.15",
+    "@diplodoc/translation": "^1.7.17",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "csp-header": "^5.2.1",

--- a/src/commands/build/features/output-html/utils.ts
+++ b/src/commands/build/features/output-html/utils.ts
@@ -28,6 +28,7 @@ import links from './plugins/links';
 import linksAutotitles from './plugins/links-autotitles';
 import linksExternal from './plugins/links-external';
 import images from './plugins/images';
+import {noTranslate} from '@diplodoc/translation';
 
 export function getBaseMdItPlugins() {
     return [
@@ -69,6 +70,7 @@ export function getBaseMdItPlugins() {
             },
         }),
         blockAnchor,
+        noTranslate({mode: 'render'}),
     ];
 }
 

--- a/src/commands/translate/run.ts
+++ b/src/commands/translate/run.ts
@@ -32,8 +32,8 @@ export class Run extends BaseRun<CommonRunConfig> {
         this.vars = new VarsService(this, {usePresets: false});
         this.meta = new MetaService(this);
         this.toc = new TocService(this);
-        this.markdown = new MarkdownService(this);
-        this.tocYamlList = new Set();
+        this.markdown = new MarkdownService(this, {mode: 'translate'});
+        this.tocYamlList = new Set<NormalizedPath>();
     }
 
     async prepareRun() {

--- a/src/core/markdown/MarkdownService.ts
+++ b/src/core/markdown/MarkdownService.ts
@@ -40,6 +40,10 @@ type Run = BaseRun<MarkdownServiceConfig> & {
     vars: VarsService;
 };
 
+type Options = {
+    mode: 'build' | 'translate';
+};
+
 function hash(this: MarkdownService, path: NormalizedPath, from: NormalizedPath[] = []) {
     return `${path}+${from[0] || ''}`;
 }
@@ -88,8 +92,11 @@ export class MarkdownService {
 
     private hash = hash;
 
-    constructor(run: Run) {
+    private options;
+
+    constructor(run: Run, options: Options = {mode: 'build'}) {
         this.run = run;
+        this.options = options;
     }
 
     @bounded async init() {
@@ -340,6 +347,7 @@ export class MarkdownService {
             options: {
                 disableLiquid: !this.config.template.enabled,
             },
+            mode: this.options.mode,
         };
     }
 }

--- a/src/core/markdown/loader.ts
+++ b/src/core/markdown/loader.ts
@@ -14,6 +14,7 @@ import {resolveComments} from './loader/resolve-comments';
 import {resolveDependencies} from './loader/resolve-deps';
 import {resolveAssets} from './loader/resolve-assets';
 import {resolveHeadings} from './loader/resolve-headings';
+import {resolveNoTranslate} from './loader/resolve-no-translate';
 
 export enum TransformMode {
     Html = 'html',
@@ -50,10 +51,12 @@ export type LoaderContext = LiquidContext & {
     options: {
         disableLiquid: boolean;
     };
+    mode: 'build' | 'translate';
 };
 
 export async function loader(this: LoaderContext, content: string) {
     content = mangleFrontMatter.call(this, content);
+    content = resolveNoTranslate.call(this, content);
     content = templateContent.call(this, content);
     content = await applyCollectPlugins.call(this, content);
     content = resolveComments.call(this, content);

--- a/src/core/markdown/loader/resolve-no-translate.ts
+++ b/src/core/markdown/loader/resolve-no-translate.ts
@@ -1,0 +1,39 @@
+import type {LoaderContext} from '../loader';
+
+export function resolveNoTranslate(this: LoaderContext, content: string) {
+    if (this.mode === 'translate') {
+        return content;
+    }
+
+    content = resolveContainerDirectives(content);
+
+    content = resolveLeafBlockDirectives(content);
+
+    content = resolveInlineDirectives(content);
+
+    return content;
+}
+
+function resolveContainerDirectives(content: string): string {
+    const containerRegex = /:::\s*no-translate\s*\n([\s\S]*?)\n\s*:::/g;
+
+    return content.replace(containerRegex, (_, innerContent) => {
+        return innerContent;
+    });
+}
+
+function resolveLeafBlockDirectives(content: string): string {
+    const blockRegex = /::\s*no-translate\s*\[([\s\S]*?)\]/g;
+
+    return content.replace(blockRegex, (_, innerContent) => {
+        return innerContent;
+    });
+}
+
+function resolveInlineDirectives(content: string): string {
+    const inlineRegex = /(?<![:]):no-translate\s*\[([\s\S]*?)\]/g;
+
+    return content.replace(inlineRegex, (_, innerContent) => {
+        return innerContent;
+    });
+}

--- a/tests/e2e/__snapshots__/translation.spec.ts.snap
+++ b/tests/e2e/__snapshots__/translation.spec.ts.snap
@@ -1,5 +1,581 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Translate command > build translated md files and remove no-translate directives > filelist 1`] = `
+"[
+  "index.md",
+  "no-translate.md",
+  "openapi/index.md",
+  "openapi/test-controller/getWithPayloadResponse.md",
+  "openapi/test-controller/index.md",
+  "toc.yaml"
+]"
+`;
+
+exports[`Translate command > build translated md files and remove no-translate directives 1`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+## Index header
+
+adsfasdfasdfasdfasdf
+
+lorem
+
+asdfasdfasdf"
+`;
+
+exports[`Translate command > build translated md files and remove no-translate directives 2`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+# No-translate directive
+
+## Block directive
+### No-translate header
+Should not be translated.
+Can use **markup** inside.
+
+## Leaf directive
+
+## /usr/local/bin/application
+**C:/Program Files/Application/config.ini**
+~/Documents/project/src/main.rs
+
+
+- GET /api/v1/users — get all users
+- POST /api/v1/auth/login — authorization
+- PUT /api/v1/users/{id} — update users data
+
+## Simple case leaf
+Install using command.
+The default port is unless specified. Next sentence.
+Set NODE_ENV=production for production builds.
+
+## Simple case inline
+Install using npm install @company/package command.
+The default port is 8080 unless specified.
+Set NODE_ENV=production for production builds.
+
+## Few inline directives
+Use **GET /api/v1/users** to list users and POST /api/v1/users to create.
+
+## Empty inline directive
+This is text with empty  directive.
+
+
+"
+`;
+
+exports[`Translate command > build translated md files and remove no-translate directives 3`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+# OpenAPI definition
+
+##version: v0##
+
+## Sections
+
+- [test-controller](test-controller/index.md)
+
+
+## Specification
+
+{% cut "Open API" %}
+
+
+\`\`\`text translate=no
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "OpenAPI definition",
+        "version": "v0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8080",
+            "description": "Generated server url"
+        }
+    ],
+    "paths": {
+        "/test": {
+            "get": {
+                "tags": [
+                    "test-controller"
+                ],
+                "summary": "Simple get operation. тест новой верстки 3",
+                "description": "Defines a simple get skip this operation with no inputs and a complex",
+                "operationId": "getWithPayloadResponse",
+                "responses": {
+                    "200": {
+                        "description": "200!!!!",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "A": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "RecurceTop": {
+                "type": "object",
+                "properties": {
+                    "A": {
+                        "type": "string"
+                    }
+                }
+            },
+            "RecurceMiddle": {
+                "type": "object",
+                "properties": {
+                    "B": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "A": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+\`\`\`
+
+
+{% endcut %}
+
+<!-- markdownlint-disable-file -->"
+`;
+
+exports[`Translate command > build translated md files and remove no-translate directives 4`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+<div class="openapi">
+
+# Simple get operation. тест новой верстки 3
+
+Defines a simple get skip this operation with no inputs and a complex
+
+## Request
+
+<div class="openapi__requests">
+
+<div class="openapi__request__wrapper" style="--method: var(--dc-openapi-methods-get);margin-bottom: 12px">
+
+<div class="openapi__request">
+
+GET {.openapi__method} 
+\`\`\`text translate=no
+http://localhost:8080/test
+\`\`\`
+
+
+
+</div>
+
+Generated server url
+
+</div>
+
+</div>
+
+## Responses
+
+<div class="openapi__response__code__200">
+
+## 200 OK
+
+200!!!!
+
+<div class="openapi-entity">
+
+### Body
+
+{% cut "application/json" %}
+
+
+\`\`\`json translate=no
+{
+    "A": "string"
+}
+\`\`\`
+
+
+{% endcut %}
+
+
+#|||
+ **Name** 
+|
+ **Description** 
+||
+
+||
+ A {.openapi-table-parameter-name} 
+|
+ **Type:** string 
+|||#
+
+</div>
+
+</div>
+<!-- markdownlint-disable-file -->
+
+</div>
+
+
+
+[*Deprecated]: No longer supported, please use an alternative and newer version."
+`;
+
+exports[`Translate command > build translated md files and remove no-translate directives 5`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+# test-controller
+
+## Endpoints
+
+- [Simple get operation. тест новой верстки 3](getWithPayloadResponse.md)
+
+<!-- markdownlint-disable-file -->"
+`;
+
+exports[`Translate command > build translated md files and remove no-translate directives 6`] = `
+"title: Test123
+href: index.md
+items:
+  - name: Не переводить
+    href: no-translate.md
+  - name: openapi
+    items:
+      - name: Overview
+        href: openapi/index.md
+      - name: test-controller
+        items:
+          - name: Overview
+            href: openapi/test-controller/index.md
+          - href: openapi/test-controller/getWithPayloadResponse.md
+            name: Simple get operation. тест новой верстки 3
+path: toc.yaml
+"
+`;
+
+exports[`Translate command > build translated static files and remove no-translate directives > filelist 1`] = `
+"[
+  "index.md",
+  "no-translate.md",
+  "openapi/index.md",
+  "openapi/test-controller/getWithPayloadResponse.md",
+  "openapi/test-controller/index.md",
+  "toc.yaml"
+]"
+`;
+
+exports[`Translate command > build translated static files and remove no-translate directives 1`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+## Index header
+
+adsfasdfasdfasdfasdf
+
+lorem
+
+asdfasdfasdf"
+`;
+
+exports[`Translate command > build translated static files and remove no-translate directives 2`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+# No-translate directive
+
+## Block directive
+### No-translate header
+Should not be translated.
+Can use **markup** inside.
+
+## Leaf directive
+
+## /usr/local/bin/application
+**C:/Program Files/Application/config.ini**
+~/Documents/project/src/main.rs
+
+
+- GET /api/v1/users — get all users
+- POST /api/v1/auth/login — authorization
+- PUT /api/v1/users/{id} — update users data
+
+## Simple case leaf
+Install using command.
+The default port is unless specified. Next sentence.
+Set NODE_ENV=production for production builds.
+
+## Simple case inline
+Install using npm install @company/package command.
+The default port is 8080 unless specified.
+Set NODE_ENV=production for production builds.
+
+## Few inline directives
+Use **GET /api/v1/users** to list users and POST /api/v1/users to create.
+
+## Empty inline directive
+This is text with empty  directive.
+
+
+"
+`;
+
+exports[`Translate command > build translated static files and remove no-translate directives 3`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+# OpenAPI definition
+
+##version: v0##
+
+## Sections
+
+- [test-controller](test-controller/index.md)
+
+
+## Specification
+
+{% cut "Open API" %}
+
+
+\`\`\`text translate=no
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "OpenAPI definition",
+        "version": "v0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8080",
+            "description": "Generated server url"
+        }
+    ],
+    "paths": {
+        "/test": {
+            "get": {
+                "tags": [
+                    "test-controller"
+                ],
+                "summary": "Simple get operation. тест новой верстки 3",
+                "description": "Defines a simple get skip this operation with no inputs and a complex",
+                "operationId": "getWithPayloadResponse",
+                "responses": {
+                    "200": {
+                        "description": "200!!!!",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "A": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "RecurceTop": {
+                "type": "object",
+                "properties": {
+                    "A": {
+                        "type": "string"
+                    }
+                }
+            },
+            "RecurceMiddle": {
+                "type": "object",
+                "properties": {
+                    "B": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "A": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+\`\`\`
+
+
+{% endcut %}
+
+<!-- markdownlint-disable-file -->"
+`;
+
+exports[`Translate command > build translated static files and remove no-translate directives 4`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+<div class="openapi">
+
+# Simple get operation. тест новой верстки 3
+
+Defines a simple get skip this operation with no inputs and a complex
+
+## Request
+
+<div class="openapi__requests">
+
+<div class="openapi__request__wrapper" style="--method: var(--dc-openapi-methods-get);margin-bottom: 12px">
+
+<div class="openapi__request">
+
+GET {.openapi__method} 
+\`\`\`text translate=no
+http://localhost:8080/test
+\`\`\`
+
+
+
+</div>
+
+Generated server url
+
+</div>
+
+</div>
+
+## Responses
+
+<div class="openapi__response__code__200">
+
+## 200 OK
+
+200!!!!
+
+<div class="openapi-entity">
+
+### Body
+
+{% cut "application/json" %}
+
+
+\`\`\`json translate=no
+{
+    "A": "string"
+}
+\`\`\`
+
+
+{% endcut %}
+
+
+#|||
+ **Name** 
+|
+ **Description** 
+||
+
+||
+ A {.openapi-table-parameter-name} 
+|
+ **Type:** string 
+|||#
+
+</div>
+
+</div>
+<!-- markdownlint-disable-file -->
+
+</div>
+
+
+
+[*Deprecated]: No longer supported, please use an alternative and newer version."
+`;
+
+exports[`Translate command > build translated static files and remove no-translate directives 5`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+---
+# test-controller
+
+## Endpoints
+
+- [Simple get operation. тест новой верстки 3](getWithPayloadResponse.md)
+
+<!-- markdownlint-disable-file -->"
+`;
+
+exports[`Translate command > build translated static files and remove no-translate directives 6`] = `
+"title: Test123
+href: index.md
+items:
+  - name: Не переводить
+    href: no-translate.md
+  - name: openapi
+    items:
+      - name: Overview
+        href: openapi/index.md
+      - name: test-controller
+        items:
+          - name: Overview
+            href: openapi/test-controller/index.md
+          - href: openapi/test-controller/getWithPayloadResponse.md
+            name: Simple get operation. тест новой верстки 3
+path: toc.yaml
+"
+`;
+
 exports[`Translate command > extract openapi spec files > filelist 1`] = `
 "[
   "openapi-spec.yaml.skl",
@@ -1099,4 +1675,536 @@ exports[`Translate command > filter files on extract with extra exclude option >
   "es/toc.yaml.skl",
   "es/toc.yaml.xliff"
 ]"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is > filelist 1`] = `
+"[
+  "index.md.skl",
+  "index.md.xliff",
+  "no-translate.md.skl",
+  "no-translate.md.xliff",
+  "openapi-spec.yaml.skl",
+  "openapi-spec.yaml.xliff",
+  "toc.yaml.skl",
+  "toc.yaml.xliff"
+]"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is 1`] = `
+"## %%%0%%%
+
+::no-translate  [adsfasdfasdfasdfasdf]
+
+%%%1%%%
+
+%%%2%%%"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is 2`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">Index header</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">lorem</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">asdfasdfasdf</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is 3`] = `
+"# %%%0%%%
+
+## %%%1%%%
+:::no-translate
+### No-translate header
+Should not be translated.
+Can use **markup** inside.
+:::
+
+## %%%2%%%
+
+::no-translate [## /usr/local/bin/application]
+::no-translate[**C:/Program Files/Application/config.ini**]
+::no-translate [~/Documents/project/src/main.rs]
+
+
+- :no-translate[GET /api/v1/users] %%%3%%%
+- :no-translate[POST /api/v1/auth/login] %%%4%%%
+- :no-translate[PUT /api/v1/users/{id}] %%%5%%%
+
+## %%%6%%%
+%%%7%%%
+:no-translate[The default port is unless specified.] %%%8%%%
+%%%9%%%
+
+## %%%10%%%
+%%%11%%%
+%%%12%%%
+%%%13%%%
+
+## %%%14%%%
+%%%15%%%
+
+## %%%16%%%
+%%%17%%%
+
+
+"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is 4`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">No-translate directive</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Block directive</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">Leaf directive</source>
+      </trans-unit>
+      <trans-unit id="3">
+        <source xml:space="preserve">— get all users</source>
+      </trans-unit>
+      <trans-unit id="4">
+        <source xml:space="preserve">— authorization</source>
+      </trans-unit>
+      <trans-unit id="5">
+        <source xml:space="preserve">— update users data</source>
+      </trans-unit>
+      <trans-unit id="6">
+        <source xml:space="preserve">Simple case leaf</source>
+      </trans-unit>
+      <trans-unit id="7">
+        <source xml:space="preserve">Install using command.</source>
+      </trans-unit>
+      <trans-unit id="8">
+        <source xml:space="preserve">Next sentence.</source>
+      </trans-unit>
+      <trans-unit id="9">
+        <source xml:space="preserve">Set NODE_ENV=production for production builds.</source>
+      </trans-unit>
+      <trans-unit id="10">
+        <source xml:space="preserve">Simple case inline</source>
+      </trans-unit>
+      <trans-unit id="11">
+        <source xml:space="preserve">Install using <x ctype="no_translate_inline" equiv-text=":no-translate[npm install @company/package]" id="x-2"/> command.</source>
+      </trans-unit>
+      <trans-unit id="12">
+        <source xml:space="preserve">The default port is <x ctype="no_translate_inline" equiv-text=":no-translate[8080]" id="x-3"/> unless specified.</source>
+      </trans-unit>
+      <trans-unit id="13">
+        <source xml:space="preserve">Set <x ctype="no_translate_inline" equiv-text=":no-translate[NODE_ENV=production]" id="x-4"/> for production builds.</source>
+      </trans-unit>
+      <trans-unit id="14">
+        <source xml:space="preserve">Few inline directives</source>
+      </trans-unit>
+      <trans-unit id="15">
+        <source xml:space="preserve">Use <x ctype="no_translate_inline" equiv-text=":no-translate[**GET /api/v1/users**]" id="x-5"/> to list users and <x ctype="no_translate_inline" equiv-text=":no-translate[POST /api/v1/users]" id="x-6"/> to create.</source>
+      </trans-unit>
+      <trans-unit id="16">
+        <source xml:space="preserve">Empty inline directive</source>
+      </trans-unit>
+      <trans-unit id="17">
+        <source xml:space="preserve">This is text with empty <x ctype="no_translate_inline" equiv-text=":no-translate[]" id="x-7"/> directive.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is 5`] = `
+"openapi: 3.0.1
+info:
+  title: '%%%0%%%'
+  version: v0
+servers:
+  - url: http://localhost:8080
+    description: '%%%1%%%'
+paths:
+  /test:
+    get:
+      tags:
+        - test-controller
+      summary: '%%%2%%%'
+      description: '%%%3%%%'
+      operationId: getWithPayloadResponse
+      responses:
+        '200':
+          description: '%%%4%%%'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecurceTop'
+components:
+  schemas:
+    RecurceTop:
+      type: object
+      properties:
+        A:
+          type: string
+    RecurceMiddle:
+      type: object
+      properties:
+        B:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecurceTop'
+"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is 6`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">OpenAPI definition</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Generated server url</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">Simple get operation. тест новой верстки 3</source>
+      </trans-unit>
+      <trans-unit id="3">
+        <source xml:space="preserve">Defines a simple get <x ctype="no_translate_inline" equiv-text=":no-translate[skip this]" id="x-1"/> operation with no inputs and a complex</source>
+      </trans-unit>
+      <trans-unit id="4">
+        <source xml:space="preserve">200!!!!</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is 7`] = `
+"title: '%%%0%%%'
+href: index.md
+items:
+  - name: '%%%1%%%'
+    href: no-translate.md
+  - name: '%%%2%%%'
+    include:
+      path: openapi
+      includers:
+        - name: openapi
+          input: openapi-spec.yaml
+"
+`;
+
+exports[`Translate command > removes no-translate directive and leaves content as is 8`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">Test123</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Не переводить</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">openapi</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > skip no-translate marked content > filelist 1`] = `
+"[
+  "index.md.skl",
+  "index.md.xliff",
+  "no-translate.md.skl",
+  "no-translate.md.xliff",
+  "openapi-spec.yaml.skl",
+  "openapi-spec.yaml.xliff",
+  "toc.yaml.skl",
+  "toc.yaml.xliff"
+]"
+`;
+
+exports[`Translate command > skip no-translate marked content 1`] = `
+"## %%%0%%%
+
+::no-translate  [adsfasdfasdfasdfasdf]
+
+%%%1%%%
+
+%%%2%%%"
+`;
+
+exports[`Translate command > skip no-translate marked content 2`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">Index header</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">lorem</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">asdfasdfasdf</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > skip no-translate marked content 3`] = `
+"# %%%0%%%
+
+## %%%1%%%
+:::no-translate
+### No-translate header
+Should not be translated.
+Can use **markup** inside.
+:::
+
+## %%%2%%%
+
+::no-translate [## /usr/local/bin/application]
+::no-translate[**C:/Program Files/Application/config.ini**]
+::no-translate [~/Documents/project/src/main.rs]
+
+
+- :no-translate[GET /api/v1/users] %%%3%%%
+- :no-translate[POST /api/v1/auth/login] %%%4%%%
+- :no-translate[PUT /api/v1/users/{id}] %%%5%%%
+
+## %%%6%%%
+%%%7%%%
+:no-translate[The default port is unless specified.] %%%8%%%
+%%%9%%%
+
+## %%%10%%%
+%%%11%%%
+%%%12%%%
+%%%13%%%
+
+## %%%14%%%
+%%%15%%%
+
+## %%%16%%%
+%%%17%%%
+
+
+"
+`;
+
+exports[`Translate command > skip no-translate marked content 4`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">No-translate directive</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Block directive</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">Leaf directive</source>
+      </trans-unit>
+      <trans-unit id="3">
+        <source xml:space="preserve">— get all users</source>
+      </trans-unit>
+      <trans-unit id="4">
+        <source xml:space="preserve">— authorization</source>
+      </trans-unit>
+      <trans-unit id="5">
+        <source xml:space="preserve">— update users data</source>
+      </trans-unit>
+      <trans-unit id="6">
+        <source xml:space="preserve">Simple case leaf</source>
+      </trans-unit>
+      <trans-unit id="7">
+        <source xml:space="preserve">Install using command.</source>
+      </trans-unit>
+      <trans-unit id="8">
+        <source xml:space="preserve">Next sentence.</source>
+      </trans-unit>
+      <trans-unit id="9">
+        <source xml:space="preserve">Set NODE_ENV=production for production builds.</source>
+      </trans-unit>
+      <trans-unit id="10">
+        <source xml:space="preserve">Simple case inline</source>
+      </trans-unit>
+      <trans-unit id="11">
+        <source xml:space="preserve">Install using <x ctype="no_translate_inline" equiv-text=":no-translate[npm install @company/package]" id="x-2"/> command.</source>
+      </trans-unit>
+      <trans-unit id="12">
+        <source xml:space="preserve">The default port is <x ctype="no_translate_inline" equiv-text=":no-translate[8080]" id="x-3"/> unless specified.</source>
+      </trans-unit>
+      <trans-unit id="13">
+        <source xml:space="preserve">Set <x ctype="no_translate_inline" equiv-text=":no-translate[NODE_ENV=production]" id="x-4"/> for production builds.</source>
+      </trans-unit>
+      <trans-unit id="14">
+        <source xml:space="preserve">Few inline directives</source>
+      </trans-unit>
+      <trans-unit id="15">
+        <source xml:space="preserve">Use <x ctype="no_translate_inline" equiv-text=":no-translate[**GET /api/v1/users**]" id="x-5"/> to list users and <x ctype="no_translate_inline" equiv-text=":no-translate[POST /api/v1/users]" id="x-6"/> to create.</source>
+      </trans-unit>
+      <trans-unit id="16">
+        <source xml:space="preserve">Empty inline directive</source>
+      </trans-unit>
+      <trans-unit id="17">
+        <source xml:space="preserve">This is text with empty <x ctype="no_translate_inline" equiv-text=":no-translate[]" id="x-7"/> directive.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > skip no-translate marked content 5`] = `
+"openapi: 3.0.1
+info:
+  title: '%%%0%%%'
+  version: v0
+servers:
+  - url: http://localhost:8080
+    description: '%%%1%%%'
+paths:
+  /test:
+    get:
+      tags:
+        - test-controller
+      summary: '%%%2%%%'
+      description: '%%%3%%%'
+      operationId: getWithPayloadResponse
+      responses:
+        '200':
+          description: '%%%4%%%'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecurceTop'
+components:
+  schemas:
+    RecurceTop:
+      type: object
+      properties:
+        A:
+          type: string
+    RecurceMiddle:
+      type: object
+      properties:
+        B:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecurceTop'
+"
+`;
+
+exports[`Translate command > skip no-translate marked content 6`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">OpenAPI definition</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Generated server url</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">Simple get operation. тест новой верстки 3</source>
+      </trans-unit>
+      <trans-unit id="3">
+        <source xml:space="preserve">Defines a simple get <x ctype="no_translate_inline" equiv-text=":no-translate[skip this]" id="x-1"/> operation with no inputs and a complex</source>
+      </trans-unit>
+      <trans-unit id="4">
+        <source xml:space="preserve">200!!!!</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > skip no-translate marked content 7`] = `
+"title: '%%%0%%%'
+href: index.md
+items:
+  - name: '%%%1%%%'
+    href: no-translate.md
+  - name: '%%%2%%%'
+    include:
+      path: openapi
+      includers:
+        - name: openapi
+          input: openapi-spec.yaml
+"
+`;
+
+exports[`Translate command > skip no-translate marked content 8`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">Test123</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Не переводить</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">openapi</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
 `;

--- a/tests/mocks/translation/no-translate/input/index.md
+++ b/tests/mocks/translation/no-translate/input/index.md
@@ -1,0 +1,7 @@
+## Index header
+
+::no-translate  [adsfasdfasdfasdfasdf]
+
+lorem
+
+asdfasdfasdf

--- a/tests/mocks/translation/no-translate/input/no-translate.md
+++ b/tests/mocks/translation/no-translate/input/no-translate.md
@@ -1,0 +1,37 @@
+# No-translate directive
+
+## Block directive
+:::no-translate
+### No-translate header
+Should not be translated.
+Can use **markup** inside.
+:::
+
+## Leaf directive
+
+::no-translate [## /usr/local/bin/application]
+::no-translate[**C:\Program Files\Application\config.ini**]
+::no-translate [~/Documents/project/src/main.rs]
+
+
+- :no-translate[GET /api/v1/users] — get all users
+- :no-translate[POST /api/v1/auth/login] — authorization
+- :no-translate[PUT /api/v1/users/{id}] — update users data
+
+## Simple case leaf
+Install using command.
+:no-translate[The default port is unless specified.] Next sentence.
+Set NODE_ENV=production for production builds.
+
+## Simple case inline
+Install using :no-translate[npm install @company/package] command.
+The default port is :no-translate[8080] unless specified.
+Set :no-translate[NODE_ENV=production] for production builds.
+
+## Few inline directives
+Use :no-translate[**GET /api/v1/users**] to list users and :no-translate[POST /api/v1/users] to create.
+
+## Empty inline directive
+This is text with empty :no-translate[] directive.
+
+

--- a/tests/mocks/translation/no-translate/input/openapi-spec.yaml
+++ b/tests/mocks/translation/no-translate/input/openapi-spec.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI definition
+  version: v0
+servers:
+  - url: http://localhost:8080
+    description: Generated server url
+paths:
+  /test:
+    get:
+      tags:
+        - test-controller
+      summary: Simple get operation. тест новой верстки 3
+      description: Defines a simple get :no-translate[skip this] operation with no inputs and a complex
+      operationId: getWithPayloadResponse
+      responses:
+        "200":
+          description: 200!!!!
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecurceTop'
+components:
+  schemas:
+    RecurceTop:
+      type: object
+      properties:
+        A:
+          type: string
+    #          $ref: '#/components/schemas/RecurceMiddle'
+    RecurceMiddle:
+      type: object
+      properties:
+        B:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecurceTop'

--- a/tests/mocks/translation/no-translate/input/toc.yaml
+++ b/tests/mocks/translation/no-translate/input/toc.yaml
@@ -1,0 +1,11 @@
+title: Test123
+href: index.md
+items:
+  - name: Не переводить
+    href: no-translate.md
+  - name: openapi
+    include:
+      path: openapi
+      includers:
+        - name: openapi
+          input: openapi-spec.yaml


### PR DESCRIPTION
No-translate directive
Uses updated @diplodoc/translation with new directive 'no-translate' which allows to mark content as none translatable.

On build removes no-translating directive but leaves its content.

Examples:

Block directive
:::no-translate
Should not be translated.
Can use markup inside.
:::

Leaf directive
::no-translate [C:\Program Files\Application\config.ini]
::no-translate [~/Documents/project/src/main.rs]

Inline directive
:no-translate[GET /api/v1/users] — get all users
:no-translate[POST /api/v1/auth/login] — authorization
:no-translate[PUT /api/v1/users/{id}] — update users data