### PR TITLE
feat: supported favicon in static

### DIFF
--- a/src/commands/build/services/entry/EntryService.ts
+++ b/src/commands/build/services/entry/EntryService.ts
@@ -100,6 +100,8 @@ export class EntryService {
             ...restYamlConfigMeta
         } = (state.data.meta as Meta) || {};
 
+        const faviconSrc = state.viewerInterface?.faviconSrc || '';
+
         const html = staticContent
             ? render({
                   ...state,
@@ -113,6 +115,7 @@ export class EntryService {
 
         template.setTitle(title);
         template.addBody(`<div id="root">${html}</div>`);
+        template.setFaviconSrc(faviconSrc);
 
         if (csp && !isEmpty(csp)) {
             template.addCsp(DEFAULT_CSP_SETTINGS);

--- a/src/core/template/template.ts
+++ b/src/core/template/template.ts
@@ -3,6 +3,7 @@ import {getCSP} from 'csp-header';
 
 import {RTL_LANGS} from '~/constants';
 import {bounded, getDepth, getDepthPath, normalizePath} from '~/core/utils';
+import { getFaviconType } from '../utils/favicon';
 
 enum ScriptPosition {
     Leading = 'leading',
@@ -55,6 +56,8 @@ export class Template {
     private body: string[] = [];
 
     private bodyClass: string[] = ['g-root', 'g-root_theme_light'];
+
+    private faviconSrc: string = '';
 
     constructor(path: RelativePath, lang: string, signs: symbol[] = []) {
         this.path = normalizePath(path);
@@ -146,9 +149,16 @@ export class Template {
         }
     }
 
+    @bounded setFaviconSrc(faviconSrc: string) {
+        this.faviconSrc = faviconSrc;
+
+        return this;
+    }
+
     dump() {
-        const {lang, title, styles, scripts, body, bodyClass} = this;
+        const {lang, title, styles, scripts, body, bodyClass, faviconSrc} = this;
         const base = getDepthPath(getDepth(this.path) - 1);
+        const faviconType = getFaviconType(faviconSrc);
 
         return dedent`
             <!DOCTYPE html>
@@ -161,6 +171,7 @@ export class Template {
                     ${this.meta.map(meta).join('\n')}
                     ${csp(this.csp)}
                     <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
+                    <link rel="icon" type="${faviconType}" href="${faviconSrc}" />
                     ${leading(scripts).map(script(this.csp)).join('\n')}
                     ${leading(styles).map(style(this.csp)).join('\n')}
                 </head>

--- a/src/core/utils/favicon.spec.ts
+++ b/src/core/utils/favicon.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getFaviconType } from './favicon';
+
+
+describe('getFaviconType', () => {
+    it('should return svg type for .svg', () => {
+        expect(getFaviconType('favicon.svg')).toBe('image/svg+xml');
+    });
+
+    it('should return png type for .png', () => {
+        expect(getFaviconType('favicon.png')).toBe('image/png');
+    });
+
+    it('should return ico type for .ico', () => {
+        expect(getFaviconType('favicon.ico')).toBe('image/x-icon');
+    });
+
+    it('should return jpeg type for .jpg', () => {
+        expect(getFaviconType('favicon.jpg')).toBe('image/jpeg');
+    });
+
+    it('should return jpeg type for .jpeg', () => {
+        expect(getFaviconType('favicon.jpeg')).toBe('image/jpeg');
+    });
+
+    it('should handle uppercase extensions', () => {
+        expect(getFaviconType('favicon.SVG')).toBe('image/svg+xml');
+        expect(getFaviconType('favicon.PNG')).toBe('image/png');
+        expect(getFaviconType('favicon.ICO')).toBe('image/x-icon');
+        expect(getFaviconType('favicon.JPG')).toBe('image/jpeg');
+        expect(getFaviconType('favicon.JPEG')).toBe('image/jpeg');
+    });
+
+    it('should return undefined for unknown extensions', () => {
+        expect(getFaviconType('favicon.bmp')).toBeUndefined();
+        expect(getFaviconType('favicon.tiff')).toBeUndefined();
+        expect(getFaviconType('favicon')).toBeUndefined();
+        expect(getFaviconType('.gitignore')).toBeUndefined();
+    });
+
+    it('should return undefined for empty input', () => {
+        expect(getFaviconType('')).toBeUndefined();
+        expect(getFaviconType(null as unknown as string)).toBeUndefined();
+        expect(getFaviconType(undefined as unknown as string)).toBeUndefined();
+    });
+
+    it('should handle full urls', () => {
+        expect(getFaviconType('https://cdn.site.com/favicon.ico')).toBe('image/x-icon');
+    });
+});

--- a/src/core/utils/favicon.ts
+++ b/src/core/utils/favicon.ts
@@ -1,0 +1,19 @@
+export function getFaviconType(faviconSrc: string): string | undefined {
+    if (!faviconSrc) return undefined;
+
+    const ext = faviconSrc.split('.').pop()?.toLowerCase();
+    
+    switch (ext) {
+        case 'svg':
+            return 'image/svg+xml';
+        case 'png':
+            return 'image/png';
+        case 'ico':
+            return 'image/x-icon';
+        case 'jpg':
+        case 'jpeg':
+            return 'image/jpeg';
+        default:
+            return undefined;
+    }
+}


### PR DESCRIPTION
Support for faviconSrc in static mode was added.
Now you can specify in your .yfm file:

```yaml
interface:
  faviconSrc: your-favicon-src
```

The favicon will be displayed correctly, and the icon type will be detected automatically.