### PR TITLE
fix: disable prefix in svg classes

### DIFF
--- a/src/commands/build/features/output-html/plugins/images.ts
+++ b/src/commands/build/features/output-html/plugins/images.ts
@@ -16,7 +16,7 @@ type Options = MarkdownItPluginOpts & {
 function prefix() {
     const value = Math.floor(Math.random() * 1e9);
 
-    return value.toString(16);
+    return 'r' + value.toString(16);
 }
 
 function convertSvg(file: NormalizedPath, state: StateCore, {assets}: Options) {
@@ -26,6 +26,7 @@ function convertSvg(file: NormalizedPath, state: StateCore, {assets}: Options) {
                 name: 'prefixIds',
                 params: {
                     prefix: prefix(),
+                    prefixClassNames: false,
                 },
             },
         ],


### PR DESCRIPTION
Disable prefix for class in svg