### PR TITLE
fix: add --filter option, warning feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@diplodoc/client": "^3.10.3",
-        "@diplodoc/liquid": "^1.3.1",
+        "@diplodoc/liquid": "^1.3.4",
         "@diplodoc/translation": "^1.7.17",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -1640,9 +1640,9 @@
       }
     },
     "node_modules/@diplodoc/liquid": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/liquid/-/liquid-1.3.1.tgz",
-      "integrity": "sha512-Hk7fae30eDCAQ0DO/v3f544Bw4ZYAPyxb6O25DqpvkRQCjKbLihPUV2JdKqP2EaMR+hmjjYrWmK9WW5RA1ETLQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@diplodoc/liquid/-/liquid-1.3.4.tgz",
+      "integrity": "sha512-aXRQVt+AIwrXwVObBT1fYaj/d7H2Wc91U4ble8st/WGi6F+swlswDlzYqt3MGZcjDYH1PeJGIOBEFtY1nIDyTg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@diplodoc/client": "^3.10.3",
-    "@diplodoc/liquid": "^1.3.1",
+    "@diplodoc/liquid": "^1.3.4",
     "@diplodoc/translation": "^1.7.17",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/src/commands/translate/__tests__/index.ts
+++ b/src/commands/translate/__tests__/index.ts
@@ -5,6 +5,7 @@ import {expect, it, vi} from 'vitest';
 import {parse} from '~/commands/parser';
 import {Translate} from '..';
 import {Run} from '../run';
+import {Extract} from '../commands/extract';
 
 // eslint-disable-next-line no-var
 var resolveConfig: Mock;
@@ -31,6 +32,18 @@ export async function runTranslate(argv: string) {
     await translate.parse(rawArgs);
 
     return translate;
+}
+
+export async function runTranslateExtract(argv: string) {
+    const extract = new Extract();
+    vi.spyOn(Run.prototype, 'prepareRun').mockImplementation(async () => undefined);
+    const rawArgs = ['node', 'index'].concat(argv.split(' '));
+    const args = parse(rawArgs, 'extract');
+
+    await extract.init(args);
+    await extract.parse(rawArgs);
+
+    return extract;
 }
 
 export function testConfig<Config = TranslateConfig>(defaultArgs: string) {

--- a/src/commands/translate/commands/extract.ts
+++ b/src/commands/translate/commands/extract.ts
@@ -1,5 +1,5 @@
 import type {BaseArgs} from '~/core/program';
-import type {ExtractOptions} from '@diplodoc/translation';
+import type {ExtractOptions, JSONObject} from '@diplodoc/translation';
 import type {Locale} from '../utils';
 
 import {ok} from 'node:assert';
@@ -19,6 +19,7 @@ import {
 import {Command, defined} from '~/core/config';
 import {YFM_CONFIG_FILENAME} from '~/constants';
 import {Extension as ExtractOpenapiIncluderFakeExtension} from '../extract-openapi';
+import {FilterExtract} from '../features/filter-extract';
 import {options} from '../config';
 import {TranslateLogger} from '../logger';
 import {
@@ -35,6 +36,7 @@ import {
 import {Run} from '../run';
 import {ConfigDefaults, configDefaults} from '../utils/config';
 import {normalizePath} from '~/core/utils';
+import {getHooks, withHooks} from './hooks';
 
 const MAX_CONCURRENCY = 50;
 
@@ -46,6 +48,7 @@ export type ExtractArgs = BaseArgs & {
     exclude?: string[];
     vars?: Hash;
     useExperimentalParser?: boolean;
+    filter?: boolean;
 };
 
 export type ExtractConfig = Pick<BaseArgs, 'input' | 'strict' | 'quiet'> & {
@@ -59,8 +62,10 @@ export type ExtractConfig = Pick<BaseArgs, 'input' | 'strict' | 'quiet'> & {
     vars: Hash;
     useExperimentalParser?: boolean;
     schema?: string;
+    filter?: boolean;
 } & ConfigDefaults;
 
+@withHooks
 @withConfigScope('translate.extract', {strict: true})
 @withConfigDefaults(() => ({
     useExperimentalParser: false,
@@ -83,9 +88,10 @@ export class Extract extends BaseProgram<ExtractConfig, ExtractArgs> {
         options.config(YFM_CONFIG_FILENAME),
         options.useExperimentalParser,
         options.schema,
+        options.filter,
     ];
 
-    readonly modules = [new ExtractOpenapiIncluderFakeExtension()];
+    readonly modules = [new ExtractOpenapiIncluderFakeExtension(), new FilterExtract()];
 
     readonly logger = new TranslateLogger();
 
@@ -95,11 +101,12 @@ export class Extract extends BaseProgram<ExtractConfig, ExtractArgs> {
         super.apply(program);
 
         getBaseHooks(this).Config.tap('Translate.Extract', (config, args) => {
-            const {input, output, quiet, strict} = pick(args, [
+            const {input, output, quiet, strict, filter} = pick(args, [
                 'input',
                 'output',
                 'quiet',
                 'strict',
+                'filter',
             ]) as ExtractArgs;
             const source = resolveSource(config, args);
             const target = resolveTargets(config, args);
@@ -121,6 +128,7 @@ export class Extract extends BaseProgram<ExtractConfig, ExtractArgs> {
                 exclude,
                 vars,
                 useExperimentalParser: defined('useExperimentalParser', args, config) || false,
+                filter,
             });
         });
     }
@@ -141,6 +149,7 @@ export class Extract extends BaseProgram<ExtractConfig, ExtractArgs> {
         this.run = new Run(this.config);
 
         await getBaseHooks(this).BeforeAnyRun.promise(this.run);
+        await getHooks(this).BeforeRun.promise(this.run);
 
         await this.run.prepareRun();
 
@@ -165,10 +174,12 @@ export class Extract extends BaseProgram<ExtractConfig, ExtractArgs> {
             await eachLimit(
                 Array.from(files),
                 MAX_CONCURRENCY,
-                asyncify(async (file: string) => {
+                asyncify(async (file: NormalizedPath) => {
                     try {
                         this.logger.extract(file);
-                        await configuredPipeline(file);
+                        const content = await this.run.getFileContent(file);
+
+                        await configuredPipeline(file, content);
                         this.logger.extracted(file);
                     } catch (error: unknown) {
                         if (error instanceof TranslateError) {
@@ -207,9 +218,8 @@ function pipeline(params: PipelineParameters) {
     const inputRoot = resolve(input);
     const outputRoot = resolve(output);
 
-    return async (path: string) => {
+    return async (path: string, content: string | JSONObject) => {
         const inputPath = join(inputRoot, path);
-        const content = new FileLoader(inputPath);
         const output = (path: string) => {
             const normalizedPath = normalizePath(path);
             const normalizedInputRoot = normalizePath(inputRoot);
@@ -220,24 +230,20 @@ function pipeline(params: PipelineParameters) {
             return join(outputRoot, targetPath);
         };
 
-        await content.load();
-
-        if (Object.keys(vars).length && content.isString) {
-            content.set(
-                liquid(content.data as string, vars, inputPath, {
-                    conditions: 'strict',
-                    substitutions: false,
-                    cycles: false,
-                }),
-            );
+        if (Object.keys(vars).length && typeof content === 'string') {
+            content = liquid(content, vars, inputPath, {
+                conditions: 'strict',
+                substitutions: false,
+                cycles: false,
+            });
         }
 
         const {schemas, ajvOptions} = await resolveSchemas({
-            content: content.data,
+            content,
             path,
             customSchemaPath: schema,
         });
-        const {xliff, skeleton, units} = extract(content.data, {
+        const {xliff, skeleton, units} = extract(content, {
             originalFile: path,
             source,
             target,

--- a/src/commands/translate/commands/hooks.ts
+++ b/src/commands/translate/commands/hooks.ts
@@ -1,0 +1,15 @@
+import type {Run} from '../run';
+
+import {AsyncSeriesHook} from 'tapable';
+
+import {generateHooksAccess} from '~/core/utils';
+
+export function hooks(name: string) {
+    return {
+        BeforeRun: new AsyncSeriesHook<Run>(['run'], `${name}.BeforeRun`),
+    };
+}
+
+const [getHooks, withHooks] = generateHooksAccess('Extract', hooks);
+
+export {getHooks, withHooks};

--- a/src/commands/translate/config.ts
+++ b/src/commands/translate/config.ts
@@ -128,6 +128,21 @@ const schema = option({
     parser: toArray,
 });
 
+const filter = option({
+    flags: '--filter',
+    desc: `
+        If enabled translates only resolved files from toc.yaml
+        If disabled translates all files from project.
+
+        Disabled by default.
+
+        Example:
+            {{PROGRAM}} --filter
+
+    `,
+    default: false,
+});
+
 export const options = {
     input: globalOptions.input,
     output: globalOptions.output,
@@ -143,4 +158,5 @@ export const options = {
     useSource,
     useExperimentalParser,
     schema,
+    filter,
 };

--- a/src/commands/translate/extract-openapi.ts
+++ b/src/commands/translate/extract-openapi.ts
@@ -12,7 +12,6 @@ type Run = BaseRun & {
 const EXTENSION = 'OpenapiIncluder';
 const INCLUDER = 'openapi';
 
-// TODO: move to openapi-extension on major
 export class Extension implements IExtension {
     apply(program: BaseProgram) {
         getBaseHooks(program).BeforeAnyRun.tap(EXTENSION, (run: Run) => {

--- a/src/commands/translate/features/filter-extract.ts
+++ b/src/commands/translate/features/filter-extract.ts
@@ -1,0 +1,56 @@
+import type {Extract} from '../commands/extract';
+import type {Run} from '../run';
+
+import {getHooks as getExtractHooks} from '../commands/hooks';
+import {getHooks as getMarkdownHooks} from '~/core/markdown';
+import {getHooks as getTocHooks} from '~/core/toc';
+
+export class FilterExtract {
+    private removedEntries: Set<NormalizedPath> = new Set();
+    private missedEntries: Set<[string, string]> = new Set();
+
+    apply(program: Extract) {
+        getExtractHooks(program).BeforeRun.tap('FilterExtract', (run) => {
+            getTocHooks(run.toc).Filtered.tap('FilterExtract', (path: NormalizedPath) => {
+                this.removedEntries.add(path);
+            });
+
+            getMarkdownHooks(run.markdown).Resolved.tapPromise(
+                'FilterExtract',
+                async (_content, path) => {
+                    if (!run.config.filter) {
+                        return;
+                    }
+
+                    const assets = await run.markdown.assets(path as RelativePath);
+
+                    for (const asset of assets) {
+                        if (
+                            asset.type === 'link' &&
+                            (this.removedEntries.has(asset.path) ||
+                                !run.toc.entries.includes(asset.path))
+                        ) {
+                            this.missedEntries.add([path, asset.path]);
+                        }
+                    }
+
+                    if (this.missedEntries.size > 0) {
+                        this.logMissedEntries(run);
+
+                        process.exit(1);
+                    }
+                },
+            );
+        });
+    }
+
+    private getErrorMessage(source: string, link: string) {
+        return `File ${source} contains link to ${link}, which was filtered from toc.yaml or it's not been included initially`;
+    }
+
+    private logMissedEntries(run: Run) {
+        for (const [key, value] of this.missedEntries) {
+            run.logger.error(this.getErrorMessage(key, value));
+        }
+    }
+}

--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -1,6 +1,6 @@
 import type {YandexTranslationConfig} from './providers/yandex';
 import {describe, expect, it, vi} from 'vitest';
-import {runTranslate as run, testConfig} from './__tests__';
+import {runTranslate as run, runTranslateExtract as runExtract, testConfig} from './__tests__';
 
 describe('Translate command', () => {
     describe('config', () => {
@@ -339,5 +339,25 @@ describe('Translate command', () => {
         expect(hasOpenApiIncluder).toBe(true);
 
         expect(extensionSpy).toHaveBeenCalled();
+    });
+
+    it('should call translate extract with option --filter', async () => {
+        const instance = await runExtract('-o output --source ru --target en --filter');
+
+        expect(instance.config).toEqual(
+            expect.objectContaining({
+                filter: true,
+            }),
+        );
+    });
+
+    it('should call translate extract without option --filter', async () => {
+        const instance = await runExtract('-o output --source ru --target en');
+
+        expect(instance.config).toEqual(
+            expect.objectContaining({
+                filter: false,
+            }),
+        );
     });
 });

--- a/src/commands/translate/run.ts
+++ b/src/commands/translate/run.ts
@@ -5,10 +5,10 @@ import {Run as BaseRun} from '~/core/run';
 import {Config} from '~/core/config';
 import {VarsService} from '~/core/vars';
 import {MetaService} from '~/core/meta';
-import {TocService} from '~/core/toc';
+import {Toc, TocService} from '~/core/toc';
 import {MarkdownService} from '~/core/markdown';
-import {join} from 'node:path';
-import {resolveFiles} from './utils';
+import {extname, join, resolve} from 'node:path';
+import {FileLoader, resolveFiles} from './utils';
 import {isMainThread} from 'node:worker_threads';
 import {ConfigDefaults} from './utils/config';
 
@@ -31,7 +31,7 @@ export class Run extends BaseRun<CommonRunConfig> {
 
         this.vars = new VarsService(this, {usePresets: false});
         this.meta = new MetaService(this);
-        this.toc = new TocService(this);
+        this.toc = new TocService(this, {skipMissingVars: true, mode: 'translate'});
         this.markdown = new MarkdownService(this, {mode: 'translate'});
         this.tocYamlList = new Set<NormalizedPath>();
     }
@@ -50,33 +50,34 @@ export class Run extends BaseRun<CommonRunConfig> {
             for (const toc of paths) {
                 this.tocYamlList.add(toc);
             }
+
+            await this.toc.init(Array.from(this.tocYamlList) as NormalizedPath[]);
         }
     }
 
-    // TODO: temp disable toc filtration on translate
     async getFiles() {
-        // const allFiles = new Set<string>();
+        const allFiles = new Set<NormalizedPath>();
 
-        // for (const entry of this.toc.entries) {
-        //     allFiles.add(entry);
-        // }
+        for (const entry of this.toc.entries) {
+            allFiles.add(entry);
+        }
 
-        // for (const entry of this.toc.entries) {
-        //     try {
-        //         const deps = await this.markdown.deps(entry as RelativePath);
+        for (const entry of this.toc.entries) {
+            try {
+                const deps = await this.markdown.deps(entry);
 
-        //         for (const dep of deps) {
-        //             if (dep.path.endsWith('.md')) {
-        //                 allFiles.add(dep.path);
-        //             }
-        //         }
-        //     } catch (error) {
-        //         this.logger.warn(error);
-        //         allFiles.delete(entry);
-        //     }
-        // }
+                for (const dep of deps) {
+                    if (dep.path.endsWith('.md')) {
+                        allFiles.add(dep.path);
+                    }
+                }
+            } catch (error) {
+                this.logger.warn(error);
+                allFiles.delete(entry);
+            }
+        }
 
-        // const allFilesArray = Array.from([...allFiles, ...this.tocYamlList]);
+        const allFilesArray = Array.from([...allFiles, ...this.tocYamlList]);
 
         return resolveFiles(
             this.config.input,
@@ -85,7 +86,29 @@ export class Run extends BaseRun<CommonRunConfig> {
             this.config.exclude,
             this.config.source.language,
             ['.md', '.yaml'],
-            [],
+            this.config.filter ? allFilesArray : null,
         );
+    }
+
+    async getFileContent(file: NormalizedPath) {
+        const type = extname(file).slice(1);
+
+        if (type === 'md') {
+            return this.markdown.load(file);
+        }
+
+        if (this.tocYamlList.has(file)) {
+            const toc: Partial<Toc> = this.toc.for(file);
+
+            delete toc.path;
+
+            return toc;
+        }
+
+        const path = resolve(this.config.input, file);
+
+        const loader = new FileLoader(path);
+
+        return loader.load();
     }
 }

--- a/src/commands/translate/utils/config.ts
+++ b/src/commands/translate/utils/config.ts
@@ -98,7 +98,7 @@ export function resolveFiles(
     exclude: string[],
     lang: string | null,
     exts: string[],
-    tocEntries: string[] = [],
+    tocEntries: string[] | null,
 ) {
     let result: string[];
     let skipped: [string, string][] = [];
@@ -118,14 +118,13 @@ export function resolveFiles(
             return acc.concat(path);
         }, [] as string[]);
     } else {
-        result =
-            tocEntries.length > 0
-                ? tocEntries
-                : globSync(extmatch, {
-                      cwd: input,
-                      nodir: true,
-                      ignore: ['node_modules/**', '*/node_modules/**'],
-                  });
+        result = tocEntries
+            ? tocEntries
+            : globSync(extmatch, {
+                  cwd: input,
+                  nodir: true,
+                  ignore: ['node_modules/**', '*/node_modules/**'],
+              });
 
         if (exclude.length) {
             [result, skipped] = skip(result, skipped, exclude, 'exclude');
@@ -193,7 +192,7 @@ export function configDefaults() {
         vars: {},
         addSystemMeta: false,
         template: {
-            enabled: false,
+            enabled: true,
             features: {
                 conditions: true,
                 substitutions: true,
@@ -204,6 +203,7 @@ export function configDefaults() {
             },
         },
         removeHiddenTocItems: false,
+        removeEmptyTocItems: false,
         outputFormat: 'md' as 'md' | 'html',
         // TODO: delete after MarkdownService redundant types delete
         allowHtml: true,

--- a/src/core/markdown/MarkdownService.ts
+++ b/src/core/markdown/MarkdownService.ts
@@ -139,7 +139,7 @@ export class MarkdownService {
 
             // TODO: this may trigger uncaught exceptions
             // But if we move this two lines above, then program exits unexpectedly
-            await getHooks(this).Resolved.promise(raw, file);
+            await getHooks(this).Resolved.promise(content, file);
         } catch (error) {
             defer.reject(error);
         }

--- a/src/core/toc/TocService.ts
+++ b/src/core/toc/TocService.ts
@@ -68,6 +68,11 @@ type Run = BaseRun<TocServiceConfig> & {
     meta: MetaService;
 };
 
+type Options = {
+    skipMissingVars: boolean;
+    mode: 'translate' | 'build';
+};
+
 @withHooks
 export class TocService {
     readonly name = 'Toc';
@@ -88,6 +93,8 @@ export class TocService {
 
     private config: TocServiceConfig;
 
+    private options;
+
     private get vars() {
         return this.run.vars;
     }
@@ -96,10 +103,11 @@ export class TocService {
         return this.run.meta;
     }
 
-    constructor(run: Run) {
+    constructor(run: Run, options: Options = {skipMissingVars: false, mode: 'build'}) {
         this.run = run;
         this.logger = run.logger;
         this.config = run.config;
+        this.options = options;
     }
 
     async init(paths: NormalizedPath[]) {
@@ -450,6 +458,8 @@ export class TocService {
             options: {
                 removeHiddenItems: this.config.removeHiddenTocItems,
                 removeEmptyItems: this.config.removeEmptyTocItems,
+                skipMissingVars: this.options.skipMissingVars,
+                mode: this.options.mode,
             },
         };
     }

--- a/src/core/toc/hooks.ts
+++ b/src/core/toc/hooks.ts
@@ -1,7 +1,13 @@
 import type {VFile} from '~/core/utils';
 import {IncludeInfo, IncluderOptions, RawToc, RawTocItem, Toc} from './types';
 
-import {AsyncParallelHook, AsyncSeriesHook, AsyncSeriesWaterfallHook, HookMap} from 'tapable';
+import {
+    AsyncParallelHook,
+    AsyncSeriesHook,
+    AsyncSeriesWaterfallHook,
+    HookMap,
+    SyncHook,
+} from 'tapable';
 
 import {generateHooksAccess} from '~/core/utils';
 
@@ -32,6 +38,7 @@ export function hooks(name: string) {
             `${name}.Included`,
         ),
         Dump: new AsyncSeriesHook<[VFile<Toc>]>(['vfile'], `${name}.Dump`),
+        Filtered: new SyncHook<[NormalizedPath]>(['path'], `${name}.Filtered`),
     };
 }
 

--- a/tests/e2e/__snapshots__/translation.spec.ts.snap
+++ b/tests/e2e/__snapshots__/translation.spec.ts.snap
@@ -612,6 +612,47 @@ path: toc.yaml
 "
 `;
 
+exports[`Translate command > do not filter files on extract > filelist 1`] = `
+"[
+  "es/_includes/test.md.skl",
+  "es/_includes/test.md.xliff",
+  "es/_no-translate/exclude.md.skl",
+  "es/_no-translate/exclude.md.xliff",
+  "es/aboba.md.skl",
+  "es/aboba.md.xliff",
+  "es/index.md.skl",
+  "es/index.md.xliff",
+  "es/nested/a1.md.skl",
+  "es/nested/a1.md.xliff",
+  "es/nested/folder1/a1.md.skl",
+  "es/nested/folder1/a1.md.xliff",
+  "es/nested/folder1/toc-i.yaml.skl",
+  "es/nested/folder1/toc-i.yaml.xliff",
+  "es/nested/index-yfm.md.skl",
+  "es/nested/index-yfm.md.xliff",
+  "es/nested/index.yaml.skl",
+  "es/nested/index.yaml.xliff",
+  "es/nested/not-in-toc.md.skl",
+  "es/nested/not-in-toc.md.xliff",
+  "es/nested/syntax/base.md.skl",
+  "es/nested/syntax/base.md.xliff",
+  "es/nested/syntax/index.md.skl",
+  "es/nested/syntax/index.md.xliff",
+  "es/nested/syntax/lists.md.skl",
+  "es/nested/syntax/lists.md.xliff",
+  "es/nested/toc.yaml.skl",
+  "es/nested/toc.yaml.xliff",
+  "es/no-var-page.md.skl",
+  "es/no-var-page.md.xliff",
+  "es/not-in-toc.md.skl",
+  "es/not-in-toc.md.xliff",
+  "es/to-be-excluded.md.skl",
+  "es/to-be-excluded.md.xliff",
+  "es/toc.yaml.skl",
+  "es/toc.yaml.xliff"
+]"
+`;
+
 exports[`Translate command > extract openapi spec files > filelist 1`] = `
 "[
   "openapi-spec.yaml.skl",
@@ -716,6 +757,7 @@ exports[`Translate command > extract openapi spec files 3`] = `
       includers:
         - name: openapi
           input: openapi-spec.yaml
+      mode: link
 "
 `;
 
@@ -1686,12 +1728,12 @@ exports[`Translate command > filter files on extract > filelist 1`] = `
 "[
   "es/_includes/test.md.skl",
   "es/_includes/test.md.xliff",
-  "es/_no-translate/exclude.md.skl",
-  "es/_no-translate/exclude.md.xliff",
   "es/aboba.md.skl",
   "es/aboba.md.xliff",
   "es/index.md.skl",
   "es/index.md.xliff",
+  "es/nested/a1.md.skl",
+  "es/nested/a1.md.xliff",
   "es/nested/index-yfm.md.skl",
   "es/nested/index-yfm.md.xliff",
   "es/nested/index.yaml.skl",
@@ -1702,6 +1744,10 @@ exports[`Translate command > filter files on extract > filelist 1`] = `
   "es/nested/syntax/lists.md.xliff",
   "es/nested/toc.yaml.skl",
   "es/nested/toc.yaml.xliff",
+  "es/no-var-page.md.skl",
+  "es/no-var-page.md.xliff",
+  "es/to-be-excluded.md.skl",
+  "es/to-be-excluded.md.xliff",
   "es/toc.yaml.skl",
   "es/toc.yaml.xliff"
 ]"
@@ -1715,6 +1761,8 @@ exports[`Translate command > filter files on extract with extra exclude option >
   "es/aboba.md.xliff",
   "es/index.md.skl",
   "es/index.md.xliff",
+  "es/nested/a1.md.skl",
+  "es/nested/a1.md.xliff",
   "es/nested/index-yfm.md.skl",
   "es/nested/index-yfm.md.xliff",
   "es/nested/index.yaml.skl",
@@ -1725,6 +1773,39 @@ exports[`Translate command > filter files on extract with extra exclude option >
   "es/nested/syntax/lists.md.xliff",
   "es/nested/toc.yaml.skl",
   "es/nested/toc.yaml.xliff",
+  "es/no-var-page.md.skl",
+  "es/no-var-page.md.xliff",
+  "es/toc.yaml.skl",
+  "es/toc.yaml.xliff"
+]"
+`;
+
+exports[`Translate command > filter files on extract with extra vars option > filelist 1`] = `
+"[
+  "es/_includes/test.md.skl",
+  "es/_includes/test.md.xliff",
+  "es/_no-translate/exclude.md.skl",
+  "es/_no-translate/exclude.md.xliff",
+  "es/aboba.md.skl",
+  "es/aboba.md.xliff",
+  "es/index.md.skl",
+  "es/index.md.xliff",
+  "es/nested/a1.md.skl",
+  "es/nested/a1.md.xliff",
+  "es/nested/index-yfm.md.skl",
+  "es/nested/index-yfm.md.xliff",
+  "es/nested/index.yaml.skl",
+  "es/nested/index.yaml.xliff",
+  "es/nested/syntax/base.md.skl",
+  "es/nested/syntax/base.md.xliff",
+  "es/nested/syntax/lists.md.skl",
+  "es/nested/syntax/lists.md.xliff",
+  "es/nested/toc.yaml.skl",
+  "es/nested/toc.yaml.xliff",
+  "es/no-var-page.md.skl",
+  "es/no-var-page.md.xliff",
+  "es/to-be-excluded.md.skl",
+  "es/to-be-excluded.md.xliff",
   "es/toc.yaml.skl",
   "es/toc.yaml.xliff"
 ]"
@@ -2239,6 +2320,288 @@ items:
 `;
 
 exports[`Translate command > skip no-translate marked content 8`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">Test123</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Не переводить</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">openapi</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > test no-translate directive > filelist 1`] = `
+"[
+  "index.md.skl",
+  "index.md.xliff",
+  "no-translate.md.skl",
+  "no-translate.md.xliff",
+  "openapi-spec.yaml.skl",
+  "openapi-spec.yaml.xliff",
+  "toc.yaml.skl",
+  "toc.yaml.xliff"
+]"
+`;
+
+exports[`Translate command > test no-translate directive 1`] = `
+"## %%%0%%%
+
+::no-translate  [adsfasdfasdfasdfasdf]
+
+%%%1%%%
+
+%%%2%%%"
+`;
+
+exports[`Translate command > test no-translate directive 2`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">Index header</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">lorem</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">asdfasdfasdf</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > test no-translate directive 3`] = `
+"# %%%0%%%
+
+## %%%1%%%
+:::no-translate
+### No-translate header
+
+:::html-block
+testsetsets
+:::
+
+::: any-other-directive
+content test
+:::
+
+Should not be translated.
+Can use **markup** inside.
+:::
+
+
+%%%2%%%
+
+## %%%3%%%
+
+::no-translate [## /usr/local/bin/application]
+::no-translate[**C:/Program Files/Application/config.ini**]
+::no-translate [~/Documents/project/src/main.rs]
+
+
+- :no-translate[GET /api/v1/users] %%%4%%%
+- :no-translate[POST /api/v1/auth/login] %%%5%%%
+- :no-translate[PUT /api/v1/users/{id}] %%%6%%%
+
+## %%%7%%%
+%%%8%%%
+:no-translate[The default port is unless specified.] %%%9%%%
+%%%10%%%
+
+## %%%11%%%
+%%%12%%%
+%%%13%%%
+%%%14%%%
+
+## %%%15%%%
+%%%16%%%
+
+## %%%17%%%
+%%%18%%%
+
+
+"
+`;
+
+exports[`Translate command > test no-translate directive 4`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">No-translate directive</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Block directive</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">::: some-other-directive<x ctype="lb" equiv-text="&amp;#10;" id="x-1"/>content here<x ctype="lb" equiv-text="&amp;#10;" id="x-2"/>:::<x ctype="lb" equiv-text="&amp;#10;" id="x-3"/>::: no-translate<x ctype="lb" equiv-text="&amp;#10;" id="x-4"/>content here<x ctype="lb" equiv-text="&amp;#10;" id="x-5"/>::: some-other-directive<x ctype="lb" equiv-text="&amp;#10;" id="x-6"/>nested content<x ctype="lb" equiv-text="&amp;#10;" id="x-7"/>:::<x ctype="lb" equiv-text="&amp;#10;" id="x-8"/>:::</source>
+      </trans-unit>
+      <trans-unit id="3">
+        <source xml:space="preserve">Leaf directive</source>
+      </trans-unit>
+      <trans-unit id="4">
+        <source xml:space="preserve">— get all users</source>
+      </trans-unit>
+      <trans-unit id="5">
+        <source xml:space="preserve">— authorization</source>
+      </trans-unit>
+      <trans-unit id="6">
+        <source xml:space="preserve">— update users data</source>
+      </trans-unit>
+      <trans-unit id="7">
+        <source xml:space="preserve">Simple case leaf</source>
+      </trans-unit>
+      <trans-unit id="8">
+        <source xml:space="preserve">Install using command.</source>
+      </trans-unit>
+      <trans-unit id="9">
+        <source xml:space="preserve">Next sentence.</source>
+      </trans-unit>
+      <trans-unit id="10">
+        <source xml:space="preserve">Set NODE_ENV=production for production builds.</source>
+      </trans-unit>
+      <trans-unit id="11">
+        <source xml:space="preserve">Simple case inline</source>
+      </trans-unit>
+      <trans-unit id="12">
+        <source xml:space="preserve">Install using <x ctype="no_translate_inline" equiv-text=":no-translate[npm install @company/package]" id="x-9"/> command.</source>
+      </trans-unit>
+      <trans-unit id="13">
+        <source xml:space="preserve">The default port is <x ctype="no_translate_inline" equiv-text=":no-translate[8080]" id="x-10"/> unless specified.</source>
+      </trans-unit>
+      <trans-unit id="14">
+        <source xml:space="preserve">Set <x ctype="no_translate_inline" equiv-text=":no-translate[NODE_ENV=production]" id="x-11"/> for production builds.</source>
+      </trans-unit>
+      <trans-unit id="15">
+        <source xml:space="preserve">Few inline directives</source>
+      </trans-unit>
+      <trans-unit id="16">
+        <source xml:space="preserve">Use <x ctype="no_translate_inline" equiv-text=":no-translate[**GET /api/v1/users**]" id="x-12"/> to list users and <x ctype="no_translate_inline" equiv-text=":no-translate[POST /api/v1/users]" id="x-13"/> to create.</source>
+      </trans-unit>
+      <trans-unit id="17">
+        <source xml:space="preserve">Empty inline directive</source>
+      </trans-unit>
+      <trans-unit id="18">
+        <source xml:space="preserve">This is text with empty <x ctype="no_translate_inline" equiv-text=":no-translate[]" id="x-14"/> directive.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > test no-translate directive 5`] = `
+"openapi: 3.0.1
+info:
+  title: '%%%0%%%'
+  version: v0
+servers:
+  - url: http://localhost:8080
+    description: '%%%1%%%'
+paths:
+  /test:
+    get:
+      tags:
+        - test-controller
+      summary: '%%%2%%%'
+      description: '%%%3%%%'
+      operationId: getWithPayloadResponse
+      responses:
+        '200':
+          description: '%%%4%%%'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecurceTop'
+components:
+  schemas:
+    RecurceTop:
+      type: object
+      properties:
+        A:
+          type: string
+    RecurceMiddle:
+      type: object
+      properties:
+        B:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecurceTop'
+"
+`;
+
+exports[`Translate command > test no-translate directive 6`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">
+    <header>
+      <skeleton>
+        <external-file href="file.skl"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id="0">
+        <source xml:space="preserve">OpenAPI definition</source>
+      </trans-unit>
+      <trans-unit id="1">
+        <source xml:space="preserve">Generated server url</source>
+      </trans-unit>
+      <trans-unit id="2">
+        <source xml:space="preserve">Simple get operation. тест новой верстки 3</source>
+      </trans-unit>
+      <trans-unit id="3">
+        <source xml:space="preserve">Defines a simple get <x ctype="no_translate_inline" equiv-text=":no-translate[skip this]" id="x-15"/> operation with no inputs and a complex</source>
+      </trans-unit>
+      <trans-unit id="4">
+        <source xml:space="preserve">200!!!!</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`Translate command > test no-translate directive 7`] = `
+"title: '%%%0%%%'
+href: index.md
+items:
+  - name: '%%%1%%%'
+    href: no-translate.md
+  - name: '%%%2%%%'
+    include:
+      path: openapi
+      includers:
+        - name: openapi
+          input: openapi-spec.yaml
+      mode: link
+"
+`;
+
+exports[`Translate command > test no-translate directive 8`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="file.ext" source-language="ru-RU" target-language="es-ES" datatype="markdown">

--- a/tests/e2e/errors.spec.ts
+++ b/tests/e2e/errors.spec.ts
@@ -18,12 +18,28 @@ function test(path: string, expect: Function) {
     });
 }
 
+
 describe('Errors', () => {
     test('mocks/errors/unreachable-link', ({html}: TestResult) => {
         expectErrors(html, [
             'ERR index.md: 1: YFM003 / unreachable-link Link is unreachable [Context: "[Unreachable link: "exists.html"][existing file](./exists.md)"]',
             'ERR index.md: 2: YFM003 / unreachable-link Link is unreachable [Context: "[Unreachable link: "missed.html"][missed file](./missed.md)"]'
         ]);
+    });
+
+    it('translate extract with filtered links', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/errors/extract-filtered-link');
+
+        const result = await TestAdapter.extract.run(inputPath, outputPath, ['--source', 'ru-RU', '--target', 'es-ES', '--filter']);
+        
+        expect(result.code).toEqual(1);
+        
+        expect(result.errors).toEqual([
+            "ERR File index.md contains link to filtered.md, which was filtered from toc.yaml or it's not been included initially",
+            "ERR File index.md contains link to filtered2.md, which was filtered from toc.yaml or it's not been included initially",
+            "ERR File index.md contains link to filtered2.md, which was filtered from toc.yaml or it's not been included initially",
+            "ERR File index.md contains link to filtered3.md, which was filtered from toc.yaml or it's not been included initially",
+        ])
     });
 });
 

--- a/tests/e2e/translation.spec.ts
+++ b/tests/e2e/translation.spec.ts
@@ -7,7 +7,7 @@ const generateMapTestTemplate = (
     args: TranslateRunArgs,
     ignoreFileContent = true,
 ) => {
-    test.skip(testTitle, async () => {
+    test(testTitle, async () => {
         const {inputPath, outputPath} = getTestPaths(testRootPath);
 
         await TestAdapter.testTranslatePass(inputPath, outputPath, args);
@@ -56,10 +56,17 @@ describe('Translate command', () => {
         target: 'es-ES',
     });
 
+    generateMapTestTemplate('do not filter files on extract', 'mocks/translation/dir-files', {
+        subcommand: 'extract',
+        source: 'ru-RU',
+        target: 'es-ES',
+    });
+
     generateMapTestTemplate('filter files on extract', 'mocks/translation/dir-files', {
         subcommand: 'extract',
         source: 'ru-RU',
         target: 'es-ES',
+        additionalArgs: '--filter'
     });
 
     generateMapTestTemplate(
@@ -69,7 +76,19 @@ describe('Translate command', () => {
             subcommand: 'extract',
             source: 'ru-RU',
             target: 'es-ES',
-            additionalArgs: '--exclude ru/_no-translate/*.md',
+            additionalArgs: '--exclude ru/to-be-excluded.md --filter',
+        },
+    );
+
+    const vars = {skip: 'prod'}
+    generateMapTestTemplate(
+        'filter files on extract with extra vars option',
+        'mocks/translation/dir-files',
+        {
+            subcommand: 'extract',
+            source: 'ru-RU',
+            target: 'es-ES',
+            additionalArgs: `--vars ${JSON.stringify(vars)} --filter`,
         },
     );
 

--- a/tests/fixtures/cliAdapter.ts
+++ b/tests/fixtures/cliAdapter.ts
@@ -34,10 +34,33 @@ class Build {
     }
 }
 
+class Extract {
+    private readonly runner: Runner;
+
+    constructor(runner: Runner) {
+        this.runner = runner;
+    }
+
+    run(input: string, output: string, args: string[]) {
+        return this.runner.runYfmDocs([
+            'translate',
+            'extract',
+            '--input',
+            input,
+            '--output',
+            output,
+            '--quiet',
+            ...args,
+        ]);
+    }
+}
+
 export class CliTestAdapter {
     readonly runner: Runner = createRunner();
 
     readonly build = new Build(this.runner);
+
+    readonly extract = new Extract(this.runner);
 
     async testBuildPass(
         inputPath: string,

--- a/tests/fixtures/utils/test.ts
+++ b/tests/fixtures/utils/test.ts
@@ -5,6 +5,11 @@ export function platformless(text: string): string {
 
     return hashless(text)
         .replace(/\r\n/g, '\n')
+        // Fix for XML equiv-text attributes in Windows - handle various patterns
+        .replace(/equiv-text="[\r\n]+&#10;"/g, 'equiv-text="&#10;"')
+        .replace(/equiv-text="[\r\n]+&amp;#10;"/g, 'equiv-text="&amp;#10;"')
+        // Also normalize any other attributes that might have line ending issues
+        .replace(/(ctype|id)="[\r\n]+(.*?)"/g, '$1="$2"')
         .replace(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/g, 'UUID')
         .replace(
             /(content"?[:=]{1}[" ]{1}Diplodoc.*? )v\d+\.\d+\.\d+(?:-[\w-]+)?/g,

--- a/tests/mocks/errors/extract-filtered-link/input/filtered.md
+++ b/tests/mocks/errors/extract-filtered-link/input/filtered.md
@@ -1,0 +1,1 @@
+File exists but not attached to toc

--- a/tests/mocks/errors/extract-filtered-link/input/index.md
+++ b/tests/mocks/errors/extract-filtered-link/input/index.md
@@ -1,0 +1,7 @@
+[filtered file](./filtered.md)
+
+{% if test == "dev" %}[will be deleted on translate-extract](./index.md){% endif %}
+
+[second missed link](./filtered2.md)
+[second missed link](./filtered2.md)
+[second missed link](./filtered3.md)

--- a/tests/mocks/errors/extract-filtered-link/input/toc.yaml
+++ b/tests/mocks/errors/extract-filtered-link/input/toc.yaml
@@ -1,0 +1,1 @@
+href: index.md

--- a/tests/mocks/translation/dir-files/input/.yfm
+++ b/tests/mocks/translation/dir-files/input/.yfm
@@ -1,0 +1,6 @@
+translate:
+    extract:
+        vars:
+            test: prod
+            skip: dev
+            

--- a/tests/mocks/translation/dir-files/input/ru/aboba.md
+++ b/tests/mocks/translation/dir-files/input/ru/aboba.md
@@ -1,7 +1,5 @@
 ## Заголовок include
 
-[ссылка на файл не в toc.yaml](./aboba-not-in-toc.md)
+<!-- [ссылка на файл не в toc.yaml](./aboba-not-in-toc.md) -->
 
 {% include [Описание](./_includes/test.md) %}
-
-

--- a/tests/mocks/translation/dir-files/input/ru/nested/a1.md
+++ b/tests/mocks/translation/dir-files/input/ru/nested/a1.md
@@ -1,0 +1,3 @@
+## Included A1
+
+TEST

--- a/tests/mocks/translation/dir-files/input/ru/nested/folder1/a1.md
+++ b/tests/mocks/translation/dir-files/input/ru/nested/folder1/a1.md
@@ -1,0 +1,3 @@
+## Included A1
+
+TEST

--- a/tests/mocks/translation/dir-files/input/ru/nested/folder1/toc-i.yaml
+++ b/tests/mocks/translation/dir-files/input/ru/nested/folder1/toc-i.yaml
@@ -1,0 +1,3 @@
+items:
+  - name: A1
+    href: a1.md

--- a/tests/mocks/translation/dir-files/input/ru/nested/syntax/base.md
+++ b/tests/mocks/translation/dir-files/input/ru/nested/syntax/base.md
@@ -1,1 +1,3 @@
 # Базовая разметка
+
+{% if test == "dev" %}[will be deleted on translate-extract](./index.md){% endif %}

--- a/tests/mocks/translation/dir-files/input/ru/nested/toc.yaml
+++ b/tests/mocks/translation/dir-files/input/ru/nested/toc.yaml
@@ -3,6 +3,7 @@ href: index.yaml
 items:
   - name: API Yandex Cloud
     href: index.yaml
+  - include: {mode: merge, path: folder1/toc-i.yaml}
   - name: Yandex Flavored Markdown
     href: index-yfm.md
     items:

--- a/tests/mocks/translation/dir-files/input/ru/no-var-page.md
+++ b/tests/mocks/translation/dir-files/input/ru/no-var-page.md
@@ -1,0 +1,3 @@
+## No var page
+
+This page might be translated or not. Depends on --strict-vars option.

--- a/tests/mocks/translation/dir-files/input/ru/to-be-excluded.md
+++ b/tests/mocks/translation/dir-files/input/ru/to-be-excluded.md
@@ -1,0 +1,1 @@
+## Excluded title

--- a/tests/mocks/translation/dir-files/input/ru/toc.yaml
+++ b/tests/mocks/translation/dir-files/input/ru/toc.yaml
@@ -4,4 +4,10 @@ items:
   - name: Aboba
     href: aboba.md
   - name: Не переводить
+    when: skip == 'prod'
     href: _no-translate/exclude.md
+  - name: Нет переменной в vars
+    when: novar == 'test'
+    href: no-var-page.md
+  - name: exclude-test
+    href: to-be-excluded.md

--- a/tests/mocks/translation/openapi/input/toc.yaml
+++ b/tests/mocks/translation/openapi/input/toc.yaml
@@ -5,4 +5,4 @@ items:
       includers:
         - name: openapi
           input: openapi-spec.yaml
-
+      mode: link

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@diplodoc/cli-tests",
       "version": "0.0.0",
       "dependencies": {
+        "@diplodoc/liquid": "^1.3.4",
         "@types/node": "18.x",
         "@vitest/coverage-istanbul": "^3.1.1",
         "@vitest/coverage-v8": "^3.1.1",
@@ -31,19 +32,18 @@
     },
     "..": {
       "name": "@diplodoc/cli",
-      "version": "5.6.0",
+      "version": "5.9.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@diplodoc/client": "^3.9.0",
-        "@diplodoc/liquid": "^1.3.1",
+        "@diplodoc/client": "^3.10.3",
+        "@diplodoc/liquid": "^1.3.4",
         "@diplodoc/translation": "^1.7.17",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
         "csp-header": "^5.2.1",
         "dependency-graph": "^1.0.0",
         "execa": "^9.5.2",
-        "express": "^5.1.0",
         "glob": "^10.4.5",
         "highlight.js": "^11.10.0",
         "js-yaml": "4.1.0",
@@ -66,16 +66,15 @@
         "@diplodoc/latex-extension": "^1.3.3",
         "@diplodoc/mermaid-extension": "^1.3.5",
         "@diplodoc/openapi-extension": "^2.8.1",
-        "@diplodoc/page-constructor-extension": "^0.5.0",
+        "@diplodoc/page-constructor-extension": "^0.10.0",
         "@diplodoc/prettier-config": "^2.0.0",
         "@diplodoc/search-extension": "^3.0.0",
-        "@diplodoc/transform": "^4.60.3",
+        "@diplodoc/transform": "^4.61.0",
         "@diplodoc/tsconfig": "^1.0.2",
         "@diplodoc/yfmlint": "^1.2.8",
         "@octokit/core": "4.2.4",
         "@types/async": "3.2.15",
         "@types/chalk": "2.2.0",
-        "@types/express": "^5.0.3",
         "@types/html-escaper": "3.0.0",
         "@types/js-yaml": "4.0.9",
         "@types/json-stringify-safe": "5.0.3",
@@ -87,6 +86,7 @@
         "ajv": "^8.11.0",
         "async": "^3.2.4",
         "axios": "^1.7.8",
+        "chokidar": "^4.0.1",
         "esbuild": "^0.23.1",
         "html-escaper": "^3.0.3",
         "husky": "8.0.3",
@@ -358,6 +358,17 @@
     "node_modules/@diplodoc/cli": {
       "resolved": "..",
       "link": true
+    },
+    "node_modules/@diplodoc/liquid": {
+      "version": "1.3.4",
+      "resolved": "https://npm.yandex-team.ru/@diplodoc%2fliquid/-/liquid-1.3.4.tgz?rbtorrent=",
+      "integrity": "sha512-aXRQVt+AIwrXwVObBT1fYaj/d7H2Wc91U4ble8st/WGi6F+swlswDlzYqt3MGZcjDYH1PeJGIOBEFtY1nIDyTg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.2",
@@ -1402,6 +1413,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://npm.yandex-team.ru/chalk/-/chalk-4.1.2.tgz?rbtorrent=c439e9071a40e546e84d959fa7090597ededbce4",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -1901,6 +1928,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://npm.yandex-team.ru/lodash/-/lodash-4.17.21.tgz?rbtorrent=921df2c64b0e0e10268c2e02b54834c8601e493d",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.1.3",

--- a/tests/package.json
+++ b/tests/package.json
@@ -27,6 +27,7 @@
     "@diplodoc/cli": "file:.."
   },
   "dependencies": {
+    "@diplodoc/liquid": "^1.3.4",
     "@types/node": "18.x",
     "@vitest/coverage-istanbul": "^3.1.1",
     "@vitest/coverage-v8": "^3.1.1",


### PR DESCRIPTION
#### Фильтрация в extract работает только при указании --filter в команде translate extract

#### Ссылки, которые ссылаются на отфильтрованные файлы или на файлы изначально отсутствующие в toc.yaml, будут считаться битыми и будет выкидываться ошибка. Выполнение extract будет остановлено.