### PR TITLE
fix: empty href prop on filtered hook, add warning

### DIFF
--- a/src/core/toc/loader.ts
+++ b/src/core/toc/loader.ts
@@ -182,9 +182,15 @@ async function resolveItems(this: LoaderContext, toc: RawToc): Promise<RawToc> {
             return item;
         }
 
+        if ('href' in item && item['href'] === null) {
+            this.logger.warn(
+                `Empty href property in item with name: ${item.name} in toc: ${this.path}`,
+            );
+        }
+
         if ('href' in item) {
             const resolvedItemHref = normalizePath(
-                join(dirname(this.path as string), item.href as string),
+                join(dirname(this.path as string), item.href || ''),
             );
 
             getHooks(this.toc).Filtered.call(resolvedItemHref);


### PR DESCRIPTION
#### Fix item.href error with message 'The "path" argument must be of type string. Received null'

Add warning, default empty string.