### PR TITLE
fix: incorrect vars in toc

### DIFF
--- a/src/core/toc/__snapshots__/index.spec.ts.snap
+++ b/src/core/toc/__snapshots__/index.spec.ts.snap
@@ -102,6 +102,83 @@ path: toc.yaml
 "
 `;
 
+exports[`toc-loader > object validation > should not throw error when nested toc item has [object Object] values but log it 1`] = `
+[
+  {
+    "items": [
+      {
+        "items": [
+          {
+            "href": "page.md",
+            "name": {
+              "[object Object]": null,
+            },
+          },
+        ],
+        "name": "Parent",
+      },
+    ],
+    "path": "toc.yaml",
+  },
+]
+`;
+
+exports[`toc-loader > object validation > should not throw error when other toc item property is [object Object] 1`] = `
+"items:
+  - name: Valid Name
+    custom:
+      '[object Object]': null
+    href: page.md
+path: toc.yaml
+"
+`;
+
+exports[`toc-loader > object validation > should not throw error when toc item items is [object Object] but log it 1`] = `
+[
+  {
+    "items": [
+      {
+        "items": [
+          {
+            "[object Object]": null,
+          },
+        ],
+        "name": "Parent",
+      },
+    ],
+    "path": "toc.yaml",
+  },
+]
+`;
+
+exports[`toc-loader > object validation > should not throw error when toc item name is [object Object] but log it 1`] = `
+[
+  {
+    "items": [
+      {
+        "href": "page.md",
+        "name": {
+          "[object Object]": null,
+        },
+      },
+    ],
+    "path": "toc.yaml",
+  },
+]
+`;
+
+exports[`toc-loader > object validation > should not throw error when toc items are valid 1`] = `
+"items:
+  - name: Valid Item
+    href: page.md
+  - name: Parent
+    items:
+      - name: Valid Child
+        href: child.md
+path: toc.yaml
+"
+`;
+
 exports[`toc-loader > should filter hidden item 1`] = `
 "items:
   - name: Visible Item 1

--- a/src/core/toc/index.spec.ts
+++ b/src/core/toc/index.spec.ts
@@ -673,4 +673,84 @@ describe('toc-loader', () => {
             expect(vfile.toString()).toMatchSnapshot();
         });
     });
+
+    describe('object validation', () => {
+        it('should not throw error when toc item name is [object Object] but log it', async () => {
+            const content = dedent`
+                items:
+                  - name: {{some_var}}
+                    href: page.md
+            `;
+
+            // Проверяем, что метод не выбрасывает исключение, а возвращает undefined
+            const {run, toc} = setupService({});
+            const files = {'toc.yaml': content};
+            mockData(run, '', {}, files, []);
+
+            const result = await toc.init(['toc.yaml'] as NormalizedPath[]);
+            // При наличии ошибок в файле toc, метод init должен вернуть пустой массив
+            expect(result).toMatchSnapshot();
+        });
+
+        it('should not throw error when toc item items is [object Object] but log it', async () => {
+            const content = dedent`
+                items:
+                  - name: Parent
+                    items: {{some_var}}
+            `;
+
+            // Проверяем, что метод не выбрасывает исключение, а возвращает undefined
+            const {run, toc} = setupService({});
+            const files = {'toc.yaml': content};
+            mockData(run, '', {}, files, []);
+
+            const result = await toc.init(['toc.yaml'] as NormalizedPath[]);
+            // При наличии ошибок в файле toc, метод init должен вернуть пустой массив
+            expect(result).toMatchSnapshot();
+        });
+
+        it('should not throw error when nested toc item has [object Object] values but log it', async () => {
+            const content = dedent`
+                items:
+                  - name: Parent
+                    items:
+                      - name: {{some_var}}
+                        href: page.md
+            `;
+
+            // Проверяем, что метод не выбрасывает исключение, а возвращает undefined
+            const {run, toc} = setupService({});
+            const files = {'toc.yaml': content};
+            mockData(run, '', {}, files, []);
+
+            const result = await toc.init(['toc.yaml'] as NormalizedPath[]);
+            // При наличии ошибок в файле toc, метод init должен вернуть пустой массив
+            expect(result).toMatchSnapshot();
+        });
+
+        it('should not throw error when other toc item property is [object Object]', async () => {
+            const content = dedent`
+                items:
+                  - name: Valid Name
+                    custom: {{some_var}}
+                    href: page.md
+            `;
+
+            await expect(test(content)()).resolves.not.toThrow();
+        });
+
+        it('should not throw error when toc items are valid', async () => {
+            const content = dedent`
+                items:
+                  - name: Valid Item
+                    href: page.md
+                  - name: Parent
+                    items:
+                      - name: Valid Child
+                        href: child.md
+            `;
+
+            await expect(test(content)()).resolves.not.toThrow();
+        });
+    });
 });

--- a/tests/e2e/errors.spec.ts
+++ b/tests/e2e/errors.spec.ts
@@ -31,6 +31,17 @@ describe('Errors', () => {
         ]);
     });
 
+    test('mocks/errors/object-validation', ({html}: TestResult) => {
+        expectErrors(html, [
+            'ERR Invalid toc structure in toc.yaml -> toc.yaml at items[1].name: found [object Object] value',
+            'ERR Invalid toc structure in toc.yaml -> toc.yaml at items[2].href: found [object Object] value',
+            'ERR Invalid toc structure in toc.yaml -> toc.yaml at items[3].items[0].name: found [object Object] value',
+            'ERR Invalid toc structure in toc.yaml -> toc.yaml at items[4].title: found [object Object] value',
+            'ERR Invalid toc structure in toc.yaml -> toc.yaml at items[5].label: found [object Object] value',
+            'ERR Invalid toc structure in toc.yaml -> toc.yaml at items[6].navigation: found [object Object] value',
+        ]);
+    });
+
     it('translate extract with filtered links', async () => {
         const {inputPath, outputPath} = getTestPaths('mocks/errors/extract-filtered-link');
 

--- a/tests/mocks/errors/object-validation/input/index.md
+++ b/tests/mocks/errors/object-validation/input/index.md
@@ -1,0 +1,3 @@
+# Test Document
+
+This is a test document for object validation.

--- a/tests/mocks/errors/object-validation/input/toc.yaml
+++ b/tests/mocks/errors/object-validation/input/toc.yaml
@@ -1,0 +1,14 @@
+items:
+  - name: Valid Item
+    href: valid.md
+  - name: {{some-var}}
+    href: invalid-name.md
+  - name: Invalid Href Item
+    href: {{some-var}}
+  - name: Parent Item
+    items:
+      - name: {{some-var}}
+        href: nested-invalid.md
+  - title: {{some-var}}
+  - label: {{some-var}}
+  - navigation: {{some-var}}


### PR DESCRIPTION
Such designs lead to a correct build, but then crashes when try render.
Adding verification and build failure
```yaml
...
  - name: {{some_var}}
...
  - items: {{some_var}}
...
```