### PR TITLE
refactor(utils): parse markdown fences in one place

### DIFF
--- a/adr/ADR-009-llms-txt.md
+++ b/adr/ADR-009-llms-txt.md
@@ -115,11 +115,12 @@ After `MarkdownCollector.collect()`, each article body is passed through
 
 #### Known limitations (accepted for simplicity and performance)
 
-Code block detection uses a simple regex that matches fenced code blocks
-(``` and ~~~). This is intentionally lightweight to avoid a second full
-markdown-it parse on every article (the loader already parses each file
-once). The following edge cases are **not** handled and are accepted as
-known limitations:
+Code block detection is a single pass over the lines that applies the
+CommonMark fence rules from `src/core/utils/fence.ts` (``` and ~~~, closing
+run at least as long as the opening one). This is intentionally lightweight
+to avoid a second full markdown-it parse on every article (the loader
+already parses each file once). The following edge cases are **not** handled
+and are accepted as known limitations:
 
 | Case                             | Example                        | Effect                                        | Impact                                                     |
 | -------------------------------- | ------------------------------ | --------------------------------------------- | ---------------------------------------------------------- |

--- a/src/commands/build/features/crawler-manifest/utils.spec.ts
+++ b/src/commands/build/features/crawler-manifest/utils.spec.ts
@@ -216,6 +216,24 @@ plain https://plain.example.com text
             expect(extractIncludePaths('`{% include [l](s.md) %}`')).toEqual([]);
         });
 
+        it('ignores includes inside a code block indented in a list', () => {
+            const content = [
+                '- item:',
+                '',
+                '    ```',
+                '    {% include [label](snippet.md) %}',
+                '    ```',
+            ].join('\n');
+
+            expect(extractIncludePaths(content)).toEqual([]);
+        });
+
+        it('does not treat inline code as a fence opener', () => {
+            const content = '```js`inline` text\n{% include [label](snippet.md) %}';
+
+            expect(extractIncludePaths(content)).toEqual(['snippet.md']);
+        });
+
         it('ignores includes with external urls', () => {
             expect(
                 extractIncludePaths('{% include [label](https://example.com/file.md) %}'),

--- a/src/commands/build/features/crawler-manifest/utils.ts
+++ b/src/commands/build/features/crawler-manifest/utils.ts
@@ -7,7 +7,7 @@ import {load as yamlLoad} from 'js-yaml';
 import MarkdownIt from 'markdown-it';
 
 import {INCLUDE_REGEX, findLink} from '~/core/markdown';
-import {isExternalHref, normalizePath, walkLinks} from '~/core/utils';
+import {isExternalHref, isFenceClose, matchFenceOpen, normalizePath, walkLinks} from '~/core/utils';
 
 import {FILE_BLOCK_REGEX, IPV4_HOST_RE, REGEXP_LITERAL} from './constants';
 
@@ -60,29 +60,29 @@ export function extractExternalLinks(content: string, {linkify = true} = {}): st
 function stripFencedBlocks(content: string): string {
     const lines = content.split('\n');
     const out: string[] = [];
-    let fenceChar = '';
-    let fenceLen = 0;
+    let markup = '';
 
     for (const line of lines) {
-        const normalized = line.replace(/\r$/, '');
+        // Indent is not limited: fences inside lists, tabs and cuts are
+        // indented deeper than the three spaces CommonMark allows, and a
+        // link shown inside such a block is still an example, not a link
+        // worth crawling.
+        const normalized = line.replace(/\r$/, '').trimStart();
 
-        if (fenceLen === 0) {
-            const fence = /^(`{3,}|~{3,})/.exec(normalized);
-
-            if (fence) {
-                fenceChar = fence[1][0];
-                fenceLen = fence[1].length;
-            } else {
-                out.push(line);
+        if (markup) {
+            if (isFenceClose(normalized, markup)) {
+                markup = '';
             }
+
+            continue;
+        }
+
+        const fence = matchFenceOpen(normalized);
+
+        if (fence) {
+            markup = fence.markup;
         } else {
-            const re = fenceChar === '`' ? /^(`{3,})[ \t]*$/ : /^(~{3,})[ \t]*$/;
-            const fence = re.exec(normalized);
-
-            if (fence && fence[1].length >= fenceLen) {
-                fenceChar = '';
-                fenceLen = 0;
-            }
+            out.push(line);
         }
     }
 

--- a/src/commands/build/features/llms/index.spec.ts
+++ b/src/commands/build/features/llms/index.spec.ts
@@ -7,12 +7,15 @@ import {OutputFormat} from '~/commands/build/config';
 
 import {LLMS_FULL_FILENAME, Llms} from './index';
 
-vi.mock('~/core/utils', () => ({
+vi.mock('~/core/utils', async () => ({
     normalizePath: (path: string) => path as NormalizedPath,
     setExt: (path: string, ext: string) => {
         const stripped = path.replace(/\.[^/.]+$/, '');
         return ext ? `${stripped}.${ext}` : stripped;
     },
+    // `stripHtmlTags` protects code blocks with these; the real ones keep
+    // the aggregator under test working on real markdown.
+    ...(await import('~/core/utils/fence')),
 }));
 
 vi.mock('~/core/program', () => ({

--- a/src/commands/build/features/llms/utils.spec.ts
+++ b/src/commands/build/features/llms/utils.spec.ts
@@ -282,6 +282,14 @@ describe('stripHtmlTags', () => {
             // The inner code block is part of the outer code block — preserved
             expect(result).toContain('<style>.x { color: red; }</style>');
         });
+
+        it('does NOT remove <style> inside a block closed by a longer fence', () => {
+            // CommonMark lets the closing run be longer than the opening one.
+            const input = ['```html', '<style>.x { color: red; }</style>', '`````'].join('\n');
+            const result = stripHtmlTags(input, ['style', 'script']);
+
+            expect(result).toContain('<style>.x { color: red; }</style>');
+        });
     });
 
     describe('include file scenario', () => {

--- a/src/commands/build/features/llms/utils.spec.ts
+++ b/src/commands/build/features/llms/utils.spec.ts
@@ -283,6 +283,22 @@ describe('stripHtmlTags', () => {
             expect(result).toContain('<style>.x { color: red; }</style>');
         });
 
+        it('does NOT remove <style> inside a backtick block wrapped in a tilde block', () => {
+            // How docs show a markdown example that itself contains a
+            // ``` block: the inner backticks are content of the ~~~ block.
+            const input = [
+                '~~~',
+                '```html',
+                '<style>.x { color: red; }</style>',
+                '```',
+                '~~~',
+            ].join('\n');
+            const result = stripHtmlTags(input, ['style', 'script']);
+
+            expect(result).toContain('<style>.x { color: red; }</style>');
+            expect(result).toBe(input);
+        });
+
         it('does NOT remove <style> inside a block closed by a longer fence', () => {
             // CommonMark lets the closing run be longer than the opening one.
             const input = ['```html', '<style>.x { color: red; }</style>', '`````'].join('\n');

--- a/src/commands/build/features/llms/utils.ts
+++ b/src/commands/build/features/llms/utils.ts
@@ -1,3 +1,50 @@
+import {isFenceClose, matchFenceOpen} from '~/core/utils';
+
+/**
+ * Replaces every fenced code block with a placeholder produced by `protect`.
+ *
+ * An unterminated fence is malformed markup rather than a code block: its
+ * lines are returned as content, so the rest of the document is still
+ * filtered (ADR-009 known limitation).
+ */
+function protectFencedBlocks(content: string, protect: (block: string) => string): string {
+    const lines = content.split('\n');
+    const out: string[] = [];
+    let block: string[] = [];
+    let markup = '';
+
+    for (const line of lines) {
+        // Leading whitespace is ignored on both ends: CommonMark allows up
+        // to three spaces, and fences inside list items are indented deeper.
+        const trimmed = line.trimStart();
+
+        if (markup) {
+            block.push(line);
+
+            if (isFenceClose(trimmed, markup)) {
+                out.push(protect(block.join('\n')));
+                block = [];
+                markup = '';
+            }
+
+            continue;
+        }
+
+        const fence = matchFenceOpen(trimmed);
+
+        if (fence) {
+            markup = fence.markup;
+            block = [line];
+        } else {
+            out.push(line);
+        }
+    }
+
+    out.push(...block);
+
+    return out.join('\n');
+}
+
 /**
  * Removes HTML tags (with content) from markdown text.
  *
@@ -16,9 +63,9 @@
  * them are preserved as-is. This is important because documentation often
  * shows `<style>`/`<script>` as examples inside code blocks.
  *
- * Code block detection uses a simple regex that matches fenced code blocks
- * (``` and ~~~). This is intentionally lightweight — it does not handle all
- * edge cases (YFM shorthand tables, deflist markers, blockquote-wrapped
+ * Code block detection is a single pass over the lines, without a second
+ * markdown-it parse. This is intentionally lightweight — it does not handle
+ * all edge cases (YFM shorthand tables, deflist markers, blockquote-wrapped
  * fences — see ADR-006 for details). These edge cases are accepted as
  * known limitations to keep the implementation simple and fast; a false
  * negative (tag inside an undetected code block gets stripped) only affects
@@ -49,14 +96,7 @@ export function stripHtmlTags(content: string, tags: string[]): string {
         return `${SENTINEL}${index}${SENTINEL}`;
     };
 
-    // Protect fence code blocks (```...``` and ~~~...~~~).
-    // Matches opening fence, content, and closing fence with the same marker.
-    // Allows optional leading whitespace (up to 3 spaces per CommonMark, but
-    // we allow any amount to also handle fences inside list items).
-    let result = content.replace(
-        /(^|\n)([ \t]*(`{3,}|~{3,})[^\n]*\n[^]*?\n[ \t]*\3)(?=\n|$)/g,
-        (_match, prefix, block) => prefix + protect(block),
-    );
+    let result = protectFencedBlocks(content, protect);
 
     // Strip HTML tags from non-code content. Process each tag separately
     // — this is faster than a combined alternation for large documents

--- a/src/commands/build/features/output-md/plugins/merge-includes.ts
+++ b/src/commands/build/features/output-md/plugins/merge-includes.ts
@@ -4,11 +4,10 @@ import type {HashedGraphNode, Scheduler, StepFunction} from '../utils';
 import {basename, dirname, join, relative} from 'node:path';
 import slugify from 'slugify';
 
-import {isExternalHref, normalizePath} from '~/core/utils';
+import {fenceCloseTail, isExternalHref, matchFenceOpen, normalizePath} from '~/core/utils';
 
 import {contentWithoutFrontmatter} from '../../output-html/plugins/includes';
 
-const CODE_FENCE_RE = /^(`{3,}|~{3,})/;
 const LINK_URL_RE = /(\]\(\s*)([^)\s]+)/g;
 const LINK_DEF_RE = /^(\s*\[(?!\*)[^\]]+\]:\s+)(\S+)(\s.*|)$/;
 const NOTITLE_RE = /\bnotitle\b/;
@@ -84,12 +83,11 @@ export function rebaseUrl(url: string, fromDir: string, toDir: string): string |
 
 interface FenceState {
     active: boolean;
-    char: string;
-    len: number;
+    markup: string;
 }
 
 function newFenceState(): FenceState {
-    return {active: false, char: '', len: 0};
+    return {active: false, markup: ''};
 }
 
 /**
@@ -98,24 +96,19 @@ function newFenceState(): FenceState {
  */
 function processCodeFence(trimmed: string, state: FenceState): boolean {
     if (state.active) {
-        const ch = state.char === '`' ? '`' : '~';
-        const closeRe = new RegExp(String.raw`^${ch}{${state.len},}(\s*$|\s*\|\|)`);
-        if (closeRe.test(trimmed)) {
+        // YFM authors glue a table row separator onto the closing line.
+        const tail = fenceCloseTail(trimmed, state.markup);
+        if (tail === '' || tail?.startsWith('||')) {
             state.active = false;
         }
         return true;
     }
 
-    const match = CODE_FENCE_RE.exec(trimmed);
-    if (match) {
-        const fence = match[1];
-        const info = trimmed.slice(fence.length);
-        if (!fence.startsWith('`') || !info.includes('`')) {
-            state.active = true;
-            state.char = fence[0];
-            state.len = fence.length;
-            return true;
-        }
+    const fence = matchFenceOpen(trimmed);
+    if (fence) {
+        state.active = true;
+        state.markup = fence.markup;
+        return true;
     }
 
     return false;

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -10,6 +10,7 @@ import {asyncify, eachLimit} from 'async';
 import liquid from '@diplodoc/transform/lib/liquid';
 
 import {LogLevel} from '~/core/logger';
+import {isFenceClose, matchFenceOpen} from '~/core/utils';
 
 import {
     FileLoader,
@@ -484,36 +485,33 @@ export function untranslatedMarker(sourceLanguage: string, targetLanguage: strin
  * Models occasionally wrap the whole response in a markdown code fence.
  * The fence is never part of the translation.
  *
- * Fences are matched as CommonMark defines them: a run of at least three
- * backticks or tildes, closed by a run of the same character at least as
- * long, with an arbitrary info string on the opening line. The model
- * picks the flavour and the length itself (a longer run when the payload
- * contains fences of its own), so a fixed three-backtick prefix leaves
- * the rest of the variants unhandled.
+ * Only a wrapper counts: the first line has to open a fence and the last
+ * one has to close it. The model picks the flavour and the length itself
+ * (a longer run when the payload contains fences of its own), so both
+ * lines go through the shared CommonMark matchers.
  */
 function stripFence(text: string): string {
     const body = text.trim();
-    const open = body.match(/^(`{3,}|~{3,})([^\n]*)\n/);
+    const firstBreak = body.indexOf('\n');
 
-    if (!open) {
+    if (firstBreak === -1) {
         return text;
     }
 
-    const [prefix, markup, info] = open;
+    const fence = matchFenceOpen(body.slice(0, firstBreak));
 
-    // A backtick fence cannot carry backticks in its info string.
-    if (markup[0] === '`' && info.includes('`')) {
+    if (!fence) {
         return text;
     }
 
-    const rest = body.slice(prefix.length);
-    const close = rest.match(/(?:^|\n)[ \t]*(`{3,}|~{3,})[ \t]*$/);
+    const rest = body.slice(firstBreak + 1);
+    const lastBreak = rest.lastIndexOf('\n');
 
-    if (!close || close[1][0] !== markup[0] || close[1].length < markup.length) {
+    if (!isFenceClose(rest.slice(lastBreak + 1).trimStart(), fence.markup)) {
         return text;
     }
 
-    return rest.slice(0, close.index).trim();
+    return rest.slice(0, lastBreak + 1).trim();
 }
 
 /**

--- a/src/core/markdown/loader/resolve-deps.ts
+++ b/src/core/markdown/loader/resolve-deps.ts
@@ -3,7 +3,13 @@ import type {LoaderContext} from '../loader';
 
 import {dirname, join} from 'node:path';
 
-import {normalizePath, parseLocalUrl, rebasePath} from '~/core/utils';
+import {
+    fenceCloseTail,
+    matchFenceOpen,
+    normalizePath,
+    parseLocalUrl,
+    rebasePath,
+} from '~/core/utils';
 
 import {INCLUDE_REGEX, filterRanges, findIncludedBlockRanges, findLink} from '../utils';
 
@@ -49,8 +55,7 @@ function findFencedCodeBlockRanges(content: string, excludeRanges: Location[] = 
     };
 
     let openLine = -1;
-    let openChar = '';
-    let openLen = 0;
+    let openMarkup = '';
 
     // Strip a leading list-item or definition-list marker from a *trimmed*
     // line so we can recognise a fence opener that lives on the same line
@@ -107,23 +112,16 @@ function findFencedCodeBlockRanges(content: string, excludeRanges: Location[] = 
         if (openLine < 0) {
             // Looking for an opener — allow a single container prefix.
             const search = stripContainerPrefix(trimmed);
-            const fenceMatch = /^(`{3,}|~{3,})/.exec(search);
-            if (!fenceMatch) {
-                continue;
-            }
             // Indent is intentionally not limited to ≤ 3 spaces (CommonMark).
             // Fences inside lists / definition lists / cuts can use deeper
             // indent (e.g. `1.` + 4 spaces).  For "is this an include shown
             // as code?" we treat any ``` / ~~~ run as a fence.
-            const fence = fenceMatch[1];
-            // Backtick fence info string must not contain backticks.
-            const info = search.slice(fence.length);
-            if (fence[0] === '`' && info.includes('`')) {
+            const fence = matchFenceOpen(search);
+            if (!fence) {
                 continue;
             }
             openLine = i;
-            openChar = fence[0];
-            openLen = fence.length;
+            openMarkup = fence.markup;
             continue;
         }
 
@@ -131,33 +129,29 @@ function findFencedCodeBlockRanges(content: string, excludeRanges: Location[] = 
         // stripped: a `- ``` ` line while we're already inside a fence is
         // just text content (CommonMark code blocks consume `-` literally),
         // not a fresh closer.
-        const startMatch = /^(`{3,}|~{3,})/.exec(trimmed);
-        if (startMatch && startMatch[1][0] === openChar && startMatch[1].length >= openLen) {
-            // Closing fence: same char, length ≥ open.  CommonMark forbids
-            // any non-whitespace content after the closing run, but in YFM
-            // real-world docs frequently glue a shorthand-table cell
-            // separator (`|`, `||`, `|#`) onto the same line as the closer
-            // (e.g. ` ``` |`).  Treat those as valid closers — otherwise
-            // the next ` ``` ` we see would be paired with this opener and
-            // we'd swallow every `{% include %}` between them.  See Bug 25.
-            const after = trimmed.slice(startMatch[1].length).trim();
-            if (after === '' || /^(?:\|\||\|#|\|)$/.test(after)) {
-                // End at the LAST char of the close-fence line content
-                // (excluding the trailing newline).  `filterRanges` below
-                // treats touching ranges (`exclude[1] === point[0]`) as
-                // overlapping, so an exclusive end on the newline position
-                // would swallow an `{% include %}` that starts on the very
-                // next line.
-                ranges.push([lineStarts[openLine], lineStarts[i] + lines[i].length]);
-                openLine = -1;
-                continue;
-            }
+        // CommonMark forbids any non-whitespace content after the closing
+        // run, but in YFM real-world docs frequently glue a shorthand-table
+        // cell separator (`|`, `||`, `|#`) onto the same line as the closer
+        // (e.g. ` ``` |`).  Treat those as valid closers — otherwise the
+        // next ` ``` ` we see would be paired with this opener and we'd
+        // swallow every `{% include %}` between them.  See Bug 25.
+        const after = fenceCloseTail(trimmed, openMarkup);
+        if (after === '' || (after !== null && /^(?:\|\||\|#|\|)$/.test(after))) {
+            // End at the LAST char of the close-fence line content
+            // (excluding the trailing newline).  `filterRanges` below
+            // treats touching ranges (`exclude[1] === point[0]`) as
+            // overlapping, so an exclusive end on the newline position
+            // would swallow an `{% include %}` that starts on the very
+            // next line.
+            ranges.push([lineStarts[openLine], lineStarts[i] + lines[i].length]);
+            openLine = -1;
+            continue;
         }
 
         // No start-of-line closer.  Check if the fence is glued to the end
         // of a content line (Bug 28).
         const endMatch = END_CLOSE_RE.exec(lines[i]);
-        if (endMatch && endMatch[1][0] === openChar && endMatch[1].length >= openLen) {
+        if (endMatch && fenceCloseTail(lines[i].slice(endMatch.index), openMarkup) !== null) {
             ranges.push([lineStarts[openLine], lineStarts[i] + lines[i].length]);
             openLine = -1;
         }

--- a/src/core/utils/fence.spec.ts
+++ b/src/core/utils/fence.spec.ts
@@ -37,6 +37,16 @@ describe('fence utils', () => {
             expect(matchFenceOpen('~~~foo`bar')).toEqual({markup: '~~~', info: 'foo`bar'});
         });
 
+        it('should open a tilde fence that wraps a backtick fence', () => {
+            // The whole point of the tilde flavour: showing a ``` block as
+            // an example. Only the run decides, the backticks below are
+            // content, and a backtick line never closes a tilde fence.
+            expect(matchFenceOpen('~~~')).toEqual({markup: '~~~', info: ''});
+            expect(matchFenceOpen('```js')).toEqual({markup: '```', info: 'js'});
+            expect(isFenceClose('```', '~~~')).toBe(false);
+            expect(isFenceClose('~~~', '~~~')).toBe(true);
+        });
+
         it('should not match an indented fence', () => {
             expect(matchFenceOpen('  ```')).toBeNull();
         });

--- a/src/core/utils/fence.spec.ts
+++ b/src/core/utils/fence.spec.ts
@@ -1,0 +1,89 @@
+import {describe, expect, it} from 'vitest';
+
+import {fenceCloseTail, isFenceClose, matchFenceOpen} from './fence';
+
+describe('fence utils', () => {
+    describe('matchFenceOpen', () => {
+        it('should match a backtick fence', () => {
+            expect(matchFenceOpen('```')).toEqual({markup: '```', info: ''});
+        });
+
+        it('should match a tilde fence', () => {
+            expect(matchFenceOpen('~~~')).toEqual({markup: '~~~', info: ''});
+        });
+
+        it('should match runs longer than three characters', () => {
+            expect(matchFenceOpen('`````')).toEqual({markup: '`````', info: ''});
+            expect(matchFenceOpen('~~~~')).toEqual({markup: '~~~~', info: ''});
+        });
+
+        it('should keep the info string', () => {
+            expect(matchFenceOpen('```js title="a.js"')).toEqual({
+                markup: '```',
+                info: 'js title="a.js"',
+            });
+        });
+
+        it('should reject runs shorter than three characters', () => {
+            expect(matchFenceOpen('``')).toBeNull();
+            expect(matchFenceOpen('~~')).toBeNull();
+        });
+
+        it('should reject a backtick fence with backticks in the info string', () => {
+            expect(matchFenceOpen('```foo`bar')).toBeNull();
+        });
+
+        it('should allow backticks in the info string of a tilde fence', () => {
+            expect(matchFenceOpen('~~~foo`bar')).toEqual({markup: '~~~', info: 'foo`bar'});
+        });
+
+        it('should not match an indented fence', () => {
+            expect(matchFenceOpen('  ```')).toBeNull();
+        });
+
+        it('should not match a line without a fence', () => {
+            expect(matchFenceOpen('text')).toBeNull();
+        });
+    });
+
+    describe('isFenceClose', () => {
+        it('should close a fence of the same length', () => {
+            expect(isFenceClose('```', '```')).toBe(true);
+        });
+
+        it('should close a fence with a longer run', () => {
+            expect(isFenceClose('`````', '```')).toBe(true);
+        });
+
+        it('should not close a fence with a shorter run', () => {
+            expect(isFenceClose('```', '````')).toBe(false);
+        });
+
+        it('should not close a fence of another character', () => {
+            expect(isFenceClose('~~~', '```')).toBe(false);
+        });
+
+        it('should allow trailing whitespace', () => {
+            expect(isFenceClose('```  \t', '```')).toBe(true);
+        });
+
+        it('should not allow trailing content', () => {
+            expect(isFenceClose('``` ||', '```')).toBe(false);
+        });
+    });
+
+    describe('fenceCloseTail', () => {
+        it('should return an empty tail for a plain closer', () => {
+            expect(fenceCloseTail('```', '```')).toBe('');
+        });
+
+        it('should return the trimmed tail', () => {
+            expect(fenceCloseTail('``` ||', '```')).toBe('||');
+        });
+
+        it('should return null for a non-closer', () => {
+            expect(fenceCloseTail('~~~', '```')).toBeNull();
+            expect(fenceCloseTail('text', '```')).toBeNull();
+        });
+    });
+});

--- a/src/core/utils/fence.ts
+++ b/src/core/utils/fence.ts
@@ -1,0 +1,64 @@
+export type Fence = {
+    /** The run of fence characters itself, e.g. ``` or ~~~~. */
+    markup: string;
+    /** Everything after the run on the opening line. */
+    info: string;
+};
+
+const FENCE_RUN_RE = /^(`{3,}|~{3,})/;
+
+/**
+ * Matches a CommonMark fence opener at the start of `line`.
+ *
+ * A fence is a run of at least three backticks or tildes. The info string
+ * of a backtick fence must not contain backticks, otherwise the run is
+ * inline code rather than a fence opener.
+ *
+ * Leading whitespace is NOT stripped: callers decide how much indent they
+ * accept (CommonMark allows three spaces, but fences inside lists, cuts
+ * and definition lists are indented deeper) and whether a container
+ * marker may precede the run.
+ */
+export function matchFenceOpen(line: string): Fence | null {
+    const match = FENCE_RUN_RE.exec(line);
+
+    if (!match) {
+        return null;
+    }
+
+    const markup = match[1];
+    const info = line.slice(markup.length);
+
+    if (markup[0] === '`' && info.includes('`')) {
+        return null;
+    }
+
+    return {markup, info};
+}
+
+/**
+ * Tells whether `line` is a CommonMark closer for a fence opened with
+ * `markup`: a run of the same character, at least as long as the opening
+ * one, with nothing but whitespace after it.
+ *
+ * YFM authors do glue table separators onto the closing line; callers
+ * that accept those inspect the tail themselves through `fenceCloseTail`.
+ */
+export function isFenceClose(line: string, markup: string): boolean {
+    return fenceCloseTail(line, markup) === '';
+}
+
+/**
+ * Returns the trimmed content that follows a closing fence run, or null
+ * when `line` does not close a fence opened with `markup`. An empty
+ * string means a plain CommonMark closer.
+ */
+export function fenceCloseTail(line: string, markup: string): string | null {
+    const match = FENCE_RUN_RE.exec(line);
+
+    if (!match || match[1][0] !== markup[0] || match[1].length < markup.length) {
+        return null;
+    }
+
+    return line.slice(match[1].length).trim();
+}

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -2,6 +2,7 @@ export * from './common';
 export * from './console';
 export * from './decorators';
 export * from './extension';
+export * from './fence';
 export * from './path';
 export * from './string';
 export * from './url';


### PR DESCRIPTION
## Problem

Follow-up to the review of #2170: fenced code blocks were parsed in five places, each with its own copy of the CommonMark rules, and two of the copies disagreed with the spec.

- `stripHtmlTags` (llms) matched the closing run with a backreference, so it required *exactly* the opening length. A block closed by a longer run stayed unprotected and the lazy body ran on to the next closer of matching length, which stripped `<style>` / `<script>` examples shown inside the block.
- `stripFencedBlocks` (crawler-manifest) matched openers at column zero only and did not know that a backtick fence cannot carry backticks in its info string. Includes inside a code block indented in a list were collected as real dependencies, and a line of inline code opened a fence that swallowed the includes after it.

The other three (`processCodeFence`, `findFencedCodeBlockRanges`, `stripFence`) agreed with the spec but each re-derived it.

## Changes

- `src/core/utils/fence.ts`: `matchFenceOpen`, `isFenceClose` and `fenceCloseTail` hold the rules - a run of at least three backticks or tildes, a closing run of the same character at least as long, and the backtick info-string restriction.
- All five call sites migrated. Policy stays local: YFM table separators glued onto the closing line, the list / definition-list prefix allowed before an opener, and how far indentation may go are still decided per site.
- Two behaviour fixes above, each with a regression test that fails on the previous implementation.
- ADR-009 keeps its list of accepted limitations; only the sentence describing the implementation changed, since detection is now a line pass instead of one regex.

Commits are split per call site.