### PR TITLE
fix(translate): do not require --auth when the auth header comes via api headers

### DIFF
--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -438,6 +438,33 @@ describe('Translate command', () => {
                 test('should handle no-cache arg', '--cache-dir .translate-cache --no-cache', {
                     cacheDir: undefined,
                 });
+
+                describe('auth via api headers', () => {
+                    const test = testConfig<AITranslationConfig>(
+                        '--source ru --target en --provider openai',
+                    );
+
+                    test(
+                        'should not require auth when Authorization header is supplied',
+                        '--api-header Authorization:OAuth-token',
+                        {
+                            auth: undefined,
+                            apiHeaders: {Authorization: 'OAuth-token'},
+                        },
+                    );
+
+                    it('should fail without auth and without auth header', async () => {
+                        vi.stubEnv('OPENAI_API_KEY', '');
+                        try {
+                            const instance = await run(
+                                '-o output --source ru --target en --provider openai --api-header X-Org:team',
+                            );
+                            expect(instance.report.code).toBe(1);
+                        } finally {
+                            vi.unstubAllEnvs();
+                        }
+                    });
+                });
             });
 
             describe('yandexgpt', () => {

--- a/src/commands/translate/providers/ai/clients/anthropic.ts
+++ b/src/commands/translate/providers/ai/clients/anthropic.ts
@@ -17,7 +17,7 @@ type AnthropicMessagesResponse = {
 };
 
 export type AnthropicClientOptions = {
-    token: string;
+    token?: string;
     model: string;
     baseUrl?: string;
     timeout?: number;
@@ -27,7 +27,7 @@ export type AnthropicClientOptions = {
 export class AnthropicClient implements LLMClient {
     readonly name = 'anthropic';
 
-    private readonly token: string;
+    private readonly token?: string;
     private readonly model: string;
     private readonly baseUrl: string;
     private readonly timeout: number;
@@ -63,7 +63,7 @@ export class AnthropicClient implements LLMClient {
                 {
                     timeout: this.timeout,
                     headers: {
-                        'x-api-key': this.token,
+                        ...(this.token ? {'x-api-key': this.token} : {}),
                         'anthropic-version': ANTHROPIC_VERSION,
                         'Content-Type': 'application/json',
                         'User-Agent': 'github.com/diplodoc-platform/cli',

--- a/src/commands/translate/providers/ai/clients/clients.spec.ts
+++ b/src/commands/translate/providers/ai/clients/clients.spec.ts
@@ -73,6 +73,20 @@ describe('translate ai clients', () => {
             expect(config.headers.Authorization).toBe('Bearer t');
         });
 
+        it('should not send default Authorization when token is absent', async () => {
+            post.mockResolvedValueOnce({data: response});
+
+            const client = createOpenAIClient({
+                model: 'internal-model',
+                baseUrl: 'https://llm.internal/v1',
+                headers: {Authorization: 'OAuth secret'},
+            });
+            await client.complete(messages, completionOptions);
+
+            const [, , config] = post.mock.calls[0];
+            expect(config.headers.Authorization).toBe('OAuth secret');
+        });
+
         it('should throw on truncated response', async () => {
             post.mockResolvedValueOnce({
                 data: {

--- a/src/commands/translate/providers/ai/clients/openai.ts
+++ b/src/commands/translate/providers/ai/clients/openai.ts
@@ -20,7 +20,7 @@ type OpenAIChatResponse = {
 };
 
 export type OpenAICompatibleClientOptions = {
-    token: string;
+    token?: string;
     model: string;
     baseUrl?: string;
     timeout?: number;
@@ -34,7 +34,7 @@ export type OpenAICompatibleClientOptions = {
 export class OpenAICompatibleClient implements LLMClient {
     readonly name: string;
 
-    private readonly token: string;
+    private readonly token?: string;
     private readonly model: string;
     private readonly baseUrl: string;
     private readonly timeout: number;
@@ -64,7 +64,7 @@ export class OpenAICompatibleClient implements LLMClient {
                 {
                     timeout: this.timeout,
                     headers: {
-                        Authorization: `Bearer ${this.token}`,
+                        ...(this.token ? {Authorization: `Bearer ${this.token}`} : {}),
                         'Content-Type': 'application/json',
                         'User-Agent': 'github.com/diplodoc-platform/cli',
                         ...this.headers,

--- a/src/commands/translate/providers/ai/clients/yandexgpt.ts
+++ b/src/commands/translate/providers/ai/clients/yandexgpt.ts
@@ -29,7 +29,7 @@ type YandexCompletionResponse = {
 };
 
 export type YandexGptClientOptions = {
-    token: string;
+    token?: string;
     model: string;
     folder?: string;
     baseUrl?: string;
@@ -64,7 +64,7 @@ function resolveModelUri(model: string, folder: string): string {
 export class YandexGptClient implements LLMClient {
     readonly name = 'yandexgpt';
 
-    private readonly token: string;
+    private readonly token?: string;
     private readonly folder: string;
     private readonly model: string;
     private readonly endpoint: string;
@@ -101,7 +101,7 @@ export class YandexGptClient implements LLMClient {
                 {
                     timeout: this.timeout,
                     headers: {
-                        Authorization: yandexAuthHeader(this.token),
+                        ...(this.token ? {Authorization: yandexAuthHeader(this.token)} : {}),
                         'Content-Type': 'application/json',
                         'User-Agent': 'github.com/diplodoc-platform/cli',
                         ...this.headers,

--- a/src/commands/translate/providers/ai/config.ts
+++ b/src/commands/translate/providers/ai/config.ts
@@ -14,6 +14,9 @@ const auth = option({
         Anthropic: x-api-key (sk-ant-...).
 
         Env fallback: YANDEX_API_KEY / YC_IAM_TOKEN, OPENAI_API_KEY, OPENROUTER_API_KEY, ANTHROPIC_API_KEY.
+
+        Optional when the provider auth header (Authorization or x-api-key)
+        is already supplied via ${cyan('--api-header')} / ${cyan('apiHeaders')}.
     `,
 });
 

--- a/src/commands/translate/providers/ai/index.ts
+++ b/src/commands/translate/providers/ai/index.ts
@@ -47,6 +47,16 @@ const ENV_BASE_URL: Record<ProviderName, string[]> = {
     anthropic: ['ANTHROPIC_BASE_URL'],
 };
 
+// The header each client would build from --auth. When the same header
+// comes from --api-header / apiHeaders (internal gateways with their own
+// auth schemes), --auth becomes redundant and is not required.
+const AUTH_HEADER: Record<ProviderName, string> = {
+    yandexgpt: 'authorization',
+    openai: 'authorization',
+    openrouter: 'authorization',
+    anthropic: 'x-api-key',
+};
+
 type Args = {
     auth?: string;
     folder?: string;
@@ -70,7 +80,7 @@ type Args = {
 };
 
 type Config = {
-    auth: string;
+    auth?: string;
     folder?: string;
     model: string;
     apiBase?: string;
@@ -229,12 +239,21 @@ export class Extension {
                 ).Config.tapPromise(`${ExtensionName}.${providerName}`, async (config, args) => {
                     ok(!config.auth, 'Do not store `authToken` in public config');
 
+                    config.apiHeaders = parseHeaders(
+                        own<string[], 'apiHeader'>(args, 'apiHeader')
+                            ? args.apiHeader
+                            : defined('apiHeaders', config),
+                    );
+
                     const rawAuth = args.auth || readEnv(ENV_AUTH[providerName]);
+                    const hasAuthHeader = Object.keys(config.apiHeaders).some(
+                        (header) => header.toLowerCase() === AUTH_HEADER[providerName],
+                    );
                     ok(
-                        rawAuth,
+                        rawAuth || hasAuthHeader,
                         `Required param --auth is not configured for provider "${providerName}"`,
                     );
-                    config.auth = resolveToken(rawAuth);
+                    config.auth = rawAuth ? resolveToken(rawAuth) : undefined;
 
                     const model =
                         (defined('model', args, config) as string | undefined) ||
@@ -246,12 +265,6 @@ export class Extension {
                     if (apiBase) {
                         config.apiBase = apiBase;
                     }
-
-                    config.apiHeaders = parseHeaders(
-                        own<string[], 'apiHeader'>(args, 'apiHeader')
-                            ? args.apiHeader
-                            : defined('apiHeaders', config),
-                    );
 
                     if (providerName === 'yandexgpt') {
                         config.folder = defined('folder', args, config);


### PR DESCRIPTION
## Summary

Internal OpenAI-compatible gateways often use their own auth scheme supplied through \`--api-header\` (for example \`Authorization: OAuth <token>\`). The provider still demanded \`--auth\`, so users had to pass a placeholder (\`--auth dummy\`) whose generated \`Bearer dummy\` header was immediately overridden by the custom one.

## Changes

- \`--auth\` is now optional when the header the client would build from it is already supplied via \`--api-header\` / \`apiHeaders\` (case-insensitive match): \`Authorization\` for openai/openrouter/yandexgpt, \`x-api-key\` for anthropic. Without either, the same "Required param --auth" error is raised.
- Clients no longer emit their default auth header when the token is absent, so nothing like \`Bearer undefined\` can leak to the wire.
- \`--auth\` help text mentions the new behavior.

Verified against a real internal gateway: a run with only \`--api-header "Authorization: OAuth ..."\` translates fine, and a run with neither \`--auth\` nor an auth header fails with the usual error.