### PR TITLE
feat(translate): support --include-vcs-diff for translating only changed files

### DIFF
--- a/src/commands/translate/config.ts
+++ b/src/commands/translate/config.ts
@@ -83,6 +83,29 @@ const exclude = option({
     parser: toArray,
 });
 
+const includeVcsDiff = option({
+    flags: '--include-vcs-diff [ref]',
+    desc: `
+        Add files changed in the current VCS working copy (git or arc)
+        to the list of files for translation.
+
+        Optional value configures the ref to compute the diff against.
+        By default the diff is computed against HEAD.
+        Untracked files are always included.
+
+        Fails if input is not inside a git or arc repository.
+        If there are no changes, the command finishes successfully without translation.
+
+        Can be combined with ${cyan('--include')} - files from both sources are translated.
+        ${cyan('--exclude')} is also applied to files from VCS diff.
+
+        Example:
+          {{PROGRAM}} --include-vcs-diff
+          {{PROGRAM}} --include-vcs-diff trunk
+          {{PROGRAM}} --include-vcs-diff origin/main
+    `,
+});
+
 const vars = option({
     flags: '-v, --vars <json>',
     desc: `
@@ -177,6 +200,7 @@ export const options = {
     files,
     include,
     exclude,
+    includeVcsDiff,
     vars,
     dryRun,
     copyAssets,

--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -2,8 +2,12 @@ import type {YandexTranslationConfig} from './providers/yandex';
 import type {AITranslationConfig} from './providers/ai';
 
 import {describe, expect, it, vi} from 'vitest';
+import {filter} from 'minimatch';
 
 import {runTranslate as run, runTranslateExtract as runExtract, testConfig} from './__tests__';
+import {resolveVcsDiffFiles} from './utils/vcs';
+
+vi.mock('./utils/vcs');
 
 describe('Translate command', () => {
     describe('config', () => {
@@ -572,5 +576,58 @@ describe('Translate command', () => {
                 refResolve: true,
             }),
         );
+    });
+
+    describe('includeVcsDiff', () => {
+        const baseArgs = '-o output --folder 1 --source ru --target en --auth y0_1';
+
+        it('should append vcs changed files to include', async () => {
+            vi.mocked(resolveVcsDiffFiles).mockReturnValue(['ru/changed.md'] as NormalizedPath[]);
+
+            const instance = await run(`${baseArgs} --include manual/** --include-vcs-diff`);
+
+            expect(resolveVcsDiffFiles).toBeCalledWith(expect.any(String), undefined);
+            expect(instance.config.include).toContain('manual/**');
+            expect(
+                instance.config.include.some((pattern) => filter(pattern)('ru/changed.md')),
+            ).toBe(true);
+        });
+
+        it('should escape glob special characters in changed paths', async () => {
+            vi.mocked(resolveVcsDiffFiles).mockReturnValue([
+                'ru/(v2)/index.md',
+            ] as NormalizedPath[]);
+
+            const instance = await run(`${baseArgs} --include-vcs-diff`);
+
+            expect(
+                instance.config.include.some((pattern) => filter(pattern)('ru/(v2)/index.md')),
+            ).toBe(true);
+        });
+
+        it('should pass ref to vcs diff', async () => {
+            vi.mocked(resolveVcsDiffFiles).mockReturnValue([]);
+
+            await run(`${baseArgs} --include-vcs-diff origin/main`);
+
+            expect(resolveVcsDiffFiles).toBeCalledWith(expect.any(String), 'origin/main');
+        });
+
+        it('should successfully skip translation when there are no vcs changes', async () => {
+            vi.mocked(resolveVcsDiffFiles).mockReturnValue([]);
+
+            const instance = await run(`${baseArgs} --include-vcs-diff`);
+
+            expect(instance.provider).toBeUndefined();
+            expect(instance.report.code).toBe(0);
+        });
+
+        it('should translate files from include when vcs diff is empty', async () => {
+            vi.mocked(resolveVcsDiffFiles).mockReturnValue([]);
+
+            const instance = await run(`${baseArgs} --include manual/** --include-vcs-diff`);
+
+            expect(instance.provider?.translate).toBeCalled();
+        });
     });
 });

--- a/src/commands/translate/index.ts
+++ b/src/commands/translate/index.ts
@@ -4,6 +4,7 @@ import type {ConfigDefaults} from './utils/config';
 
 import {ok} from 'assert';
 import {pick} from 'lodash';
+import {escape as escapeGlob} from 'minimatch';
 
 import {
     BaseProgram,
@@ -20,7 +21,7 @@ import {Extract} from './commands/extract';
 import {Compose} from './commands/compose';
 import {Extension as YandexTranslation} from './providers/yandex';
 import {Extension as AITranslation} from './providers/ai';
-import {copyAssets, resolveSource, resolveTargets, resolveVars} from './utils';
+import {copyAssets, resolveSource, resolveTargets, resolveVars, resolveVcsDiffFiles} from './utils';
 import {Run} from './run';
 import {configDefaults} from './utils/config';
 import {Extension as ExtractOpenapiIncluderFakeExtension} from './extract-openapi';
@@ -39,6 +40,7 @@ export type TranslateArgs = BaseArgs & {
     target?: string | string[];
     include?: string[];
     exclude?: string[];
+    includeVcsDiff?: string | boolean;
     vars?: Hash;
     copyAssets?: boolean;
 };
@@ -50,6 +52,7 @@ export type TranslateConfig = Pick<BaseArgs, 'input' | 'strict' | 'quiet'> & {
     target: Locale[];
     include: string[];
     exclude: string[];
+    includeVcsDiff?: string | boolean;
     files: string[];
     skipped: [string, string][];
     vars: Hash;
@@ -78,6 +81,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
         options.files,
         options.include,
         options.exclude,
+        options.includeVcsDiff,
         options.vars,
         options.dryRun,
         options.copyAssets,
@@ -101,6 +105,8 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
 
     private run!: Run;
 
+    private vcsDiffFiles?: NormalizedPath[];
+
     apply(program?: BaseProgram) {
         super.apply(program);
 
@@ -115,6 +121,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
             const target = resolveTargets(config, args);
             const include = defined('include', args, config) || [];
             const exclude = defined('exclude', args, config) || [];
+            const includeVcsDiff = defined('includeVcsDiff', args, config) || false;
             const files = defined('files', args, config);
             const vars = resolveVars(config, args);
 
@@ -128,6 +135,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
                 target,
                 include,
                 exclude,
+                includeVcsDiff,
                 vars,
                 provider: defined('provider', args, config),
                 dryRun: defined('dryRun', args, config) || false,
@@ -140,6 +148,18 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
     }
 
     async action() {
+        if (this.config.includeVcsDiff) {
+            const changed = this.getVcsDiffFiles();
+            const {include, files} = this.config;
+
+            if (!changed.length && !include.length && !(files && files.length)) {
+                this.logger.info('No VCS changes found, nothing to translate.');
+                return;
+            }
+
+            this.config.include = include.concat(changed.map((file) => escapeGlob(file)));
+        }
+
         this.run = new Run(this.config);
 
         await getBaseHooks(this).BeforeAnyRun.promise(this.run);
@@ -173,5 +193,18 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
         this.command.helpOption(true).allowUnknownOption(false);
 
         await this.parse(args(this.command));
+    }
+
+    private getVcsDiffFiles(): NormalizedPath[] {
+        if (!this.vcsDiffFiles) {
+            const ref =
+                typeof this.config.includeVcsDiff === 'string'
+                    ? this.config.includeVcsDiff
+                    : undefined;
+
+            this.vcsDiffFiles = resolveVcsDiffFiles(this.config.input, ref);
+        }
+
+        return this.vcsDiffFiles;
     }
 }

--- a/src/commands/translate/index.ts
+++ b/src/commands/translate/index.ts
@@ -152,7 +152,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
             const changed = this.getVcsDiffFiles();
             const {include, files} = this.config;
 
-            if (!changed.length && !include.length && !(files && files.length)) {
+            if (!changed.length && !include.length && !files?.length) {
                 this.logger.info('No VCS changes found, nothing to translate.');
                 return;
             }

--- a/src/commands/translate/utils/config.spec.ts
+++ b/src/commands/translate/utils/config.spec.ts
@@ -25,6 +25,11 @@ afterEach(() => {
     }
 });
 
+// resolveFiles returns platform-native separators, tests expect posix ones.
+function normalize(files: string[]) {
+    return files.map((file) => file.replace(/\\/g, '/'));
+}
+
 describe('resolveFiles', () => {
     it('keeps files matched by any of multiple include patterns', () => {
         const root = makeProject(['ru/a.md', 'ru/b.md', 'ru/c.md']);
@@ -39,7 +44,7 @@ describe('resolveFiles', () => {
             null,
         );
 
-        expect(result.sort()).toEqual(['ru/a.md', 'ru/b.md']);
+        expect(normalize(result).sort()).toEqual(['ru/a.md', 'ru/b.md']);
     });
 
     it('applies exclude to included files', () => {
@@ -55,6 +60,6 @@ describe('resolveFiles', () => {
             null,
         );
 
-        expect(result).toEqual(['ru/a.md']);
+        expect(normalize(result)).toEqual(['ru/a.md']);
     });
 });

--- a/src/commands/translate/utils/config.spec.ts
+++ b/src/commands/translate/utils/config.spec.ts
@@ -1,0 +1,60 @@
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {resolveFiles} from './config';
+
+const dirs: string[] = [];
+
+function makeProject(files: string[]) {
+    const root = mkdtempSync(join(tmpdir(), 'yfm-resolve-files-'));
+    dirs.push(root);
+
+    for (const file of files) {
+        mkdirSync(join(root, dirname(file)), {recursive: true});
+        writeFileSync(join(root, file), '');
+    }
+
+    return root;
+}
+
+afterEach(() => {
+    while (dirs.length) {
+        rmSync(dirs.pop() as string, {recursive: true, force: true});
+    }
+});
+
+describe('resolveFiles', () => {
+    it('keeps files matched by any of multiple include patterns', () => {
+        const root = makeProject(['ru/a.md', 'ru/b.md', 'ru/c.md']);
+
+        const [result] = resolveFiles(
+            root,
+            null,
+            ['ru/a.md', 'ru/b.md'],
+            [],
+            'ru',
+            ['.md', '.yaml'],
+            null,
+        );
+
+        expect(result.sort()).toEqual(['ru/a.md', 'ru/b.md']);
+    });
+
+    it('applies exclude to included files', () => {
+        const root = makeProject(['ru/a.md', 'ru/b.md']);
+
+        const [result] = resolveFiles(
+            root,
+            null,
+            ['ru/a.md', 'ru/b.md'],
+            ['ru/b.md'],
+            'ru',
+            ['.md', '.yaml'],
+            null,
+        );
+
+        expect(result).toEqual(['ru/a.md']);
+    });
+});

--- a/src/commands/translate/utils/config.ts
+++ b/src/commands/translate/utils/config.ts
@@ -166,9 +166,12 @@ function skip(
     reason: string,
     negate = false,
 ) {
-    const mode = (value: boolean) => (negate ? !value : value);
     const patterns = ([] as string[]).concat(pattern).map((pattern) => filter(pattern));
-    const match = (value: string) => patterns.some((match) => mode(match(value)));
+    const match = (value: string) => {
+        const matched = patterns.some((match) => match(value));
+
+        return negate ? !matched : matched;
+    };
 
     return array.reduce(
         ([left, right], value) => {

--- a/src/commands/translate/utils/index.ts
+++ b/src/commands/translate/utils/index.ts
@@ -2,6 +2,7 @@ export type {Locale} from './config';
 export {resolveSchemas, FileLoader, copyAssets, languageRepath} from './fs';
 export {extract, compose} from './translate';
 export {resolveSource, resolveTargets, resolveFiles, resolveVars} from './config';
+export {resolveVcsDiffFiles} from './vcs';
 export {
     TranslateError,
     ExtractError,

--- a/src/commands/translate/utils/vcs.spec.ts
+++ b/src/commands/translate/utils/vcs.spec.ts
@@ -1,0 +1,148 @@
+import {execFileSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {resolveVcsDiffFiles} from './vcs';
+
+const dirs: string[] = [];
+
+function makeDir(prefix: string) {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    dirs.push(dir);
+
+    return dir;
+}
+
+function makeRepo() {
+    const root = makeDir('yfm-vcs-git-');
+    git(root, 'init', '-q', '-b', 'main');
+
+    return root;
+}
+
+function git(cwd: string, ...args: string[]) {
+    execFileSync('git', ['-c', 'user.email=test@example.com', '-c', 'user.name=test', ...args], {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}
+
+function write(root: string, path: string, content: string) {
+    mkdirSync(join(root, dirname(path)), {recursive: true});
+    writeFileSync(join(root, path), content);
+}
+
+afterEach(() => {
+    while (dirs.length) {
+        rmSync(dirs.pop() as string, {recursive: true, force: true});
+    }
+});
+
+describe('resolveVcsDiffFiles', () => {
+    describe('git', () => {
+        it('collects modified and untracked files', () => {
+            const root = makeRepo();
+            write(root, 'ru/index.md', 'old');
+            git(root, 'add', '.');
+            git(root, 'commit', '-qm', 'init');
+            write(root, 'ru/index.md', 'new');
+            write(root, 'ru/new.md', 'new file');
+
+            const result = resolveVcsDiffFiles(root as AbsolutePath);
+
+            expect(result.sort()).toEqual(['ru/index.md', 'ru/new.md']);
+        });
+
+        it('scopes result to input and rebases paths', () => {
+            const root = makeRepo();
+            write(root, 'docs/ru/index.md', 'old');
+            write(root, 'other/readme.md', 'old');
+            git(root, 'add', '.');
+            git(root, 'commit', '-qm', 'init');
+            write(root, 'docs/ru/index.md', 'new');
+            write(root, 'other/readme.md', 'new');
+
+            const result = resolveVcsDiffFiles(join(root, 'docs') as AbsolutePath);
+
+            expect(result).toEqual(['ru/index.md']);
+        });
+
+        it('computes diff against passed ref', () => {
+            const root = makeRepo();
+            write(root, 'ru/index.md', 'old');
+            git(root, 'add', '.');
+            git(root, 'commit', '-qm', 'init');
+            write(root, 'ru/index.md', 'new');
+            git(root, 'add', '.');
+            git(root, 'commit', '-qm', 'change');
+
+            expect(resolveVcsDiffFiles(root as AbsolutePath)).toEqual([]);
+            expect(resolveVcsDiffFiles(root as AbsolutePath, 'HEAD~1')).toEqual(['ru/index.md']);
+        });
+
+        it('throws when no repository found', () => {
+            const dir = makeDir('yfm-vcs-none-');
+
+            expect(() => resolveVcsDiffFiles(dir as AbsolutePath)).toThrow(/git or arc/);
+        });
+    });
+
+    describe('arc', () => {
+        function fakeArc(root: string, {diff = '', untracked = [] as string[]} = {}) {
+            const calls: string[][] = [];
+            const runner = (cmd: string, args: string[]) => {
+                calls.push([cmd, ...args]);
+
+                if (cmd === 'git') {
+                    throw new Error('not a git repository');
+                }
+
+                if (args[0] === 'root') {
+                    return root + '\n';
+                }
+
+                if (args[0] === 'diff') {
+                    return diff;
+                }
+
+                if (args[0] === 'status') {
+                    return JSON.stringify({
+                        status: {
+                            untracked: untracked.map((path) => ({
+                                status: 'untracked',
+                                type: 'file',
+                                path,
+                            })),
+                        },
+                    });
+                }
+
+                throw new Error(`Unexpected call: ${cmd} ${args.join(' ')}`);
+            };
+
+            return {calls, runner};
+        }
+
+        it('falls back to arc and collects diff with untracked files', () => {
+            const {runner} = fakeArc('/repo', {
+                diff: 'docs/ru/index.md\n',
+                untracked: ['docs/ru/new.md'],
+            });
+
+            const result = resolveVcsDiffFiles('/repo/docs' as AbsolutePath, undefined, runner);
+
+            expect(result.sort()).toEqual(['ru/index.md', 'ru/new.md']);
+        });
+
+        it('passes ref to arc diff', () => {
+            const {calls, runner} = fakeArc('/repo');
+
+            resolveVcsDiffFiles('/repo' as AbsolutePath, 'trunk', runner);
+
+            expect(calls).toContainEqual(['arc', 'diff', '--name-only', 'trunk']);
+        });
+    });
+});

--- a/src/commands/translate/utils/vcs.spec.ts
+++ b/src/commands/translate/utils/vcs.spec.ts
@@ -144,5 +144,29 @@ describe('resolveVcsDiffFiles', () => {
 
             expect(calls).toContainEqual(['arc', 'diff', '--name-only', 'trunk']);
         });
+
+        it('expands range ref into two commits for arc', () => {
+            const {calls, runner} = fakeArc('/repo');
+
+            resolveVcsDiffFiles('/repo' as AbsolutePath, 'r1..r2', runner);
+
+            expect(calls).toContainEqual(['arc', 'diff', '--name-only', 'r1', 'r2']);
+        });
+
+        it('expands merge-base range ref into -B form for arc', () => {
+            const {calls, runner} = fakeArc('/repo');
+
+            resolveVcsDiffFiles('/repo' as AbsolutePath, 'trunk...HEAD', runner);
+
+            expect(calls).toContainEqual(['arc', 'diff', '--name-only', '-B', 'trunk', 'HEAD']);
+        });
+
+        it('substitutes HEAD for open-ended range refs for arc', () => {
+            const {calls, runner} = fakeArc('/repo');
+
+            resolveVcsDiffFiles('/repo' as AbsolutePath, 'trunk..', runner);
+
+            expect(calls).toContainEqual(['arc', 'diff', '--name-only', 'trunk', 'HEAD']);
+        });
     });
 });

--- a/src/commands/translate/utils/vcs.ts
+++ b/src/commands/translate/utils/vcs.ts
@@ -78,12 +78,20 @@ function arcChangedFiles(root: AbsolutePath, ref: string, runner: VcsRunner) {
     return lines(diff).concat(untracked);
 }
 
-function realScope(input: AbsolutePath): AbsolutePath {
-    try {
-        return realpathSync(input) as AbsolutePath;
-    } catch {
-        return resolve(input) as AbsolutePath;
+function toRealPath(path: string): AbsolutePath {
+    // On Windows git may report the repository root with 8.3 short names
+    // (C:/Users/RUNNER~1/...), while the input path is expanded.
+    // realpathSync.native resolves both short names and symlinks,
+    // so both paths land in the same form and can be safely rebased.
+    for (const resolver of [realpathSync.native, realpathSync]) {
+        try {
+            return resolver(path) as AbsolutePath;
+        } catch {
+            // Path may not exist - try the next resolver.
+        }
     }
+
+    return resolve(path) as AbsolutePath;
 }
 
 /**
@@ -104,10 +112,11 @@ export function resolveVcsDiffFiles(
     const {type, root} = detectVcs(input, runner);
     const files =
         type === 'git' ? gitChangedFiles(root, ref, runner) : arcChangedFiles(root, ref, runner);
-    const scope = realScope(input);
+    const scope = toRealPath(input);
+    const base = toRealPath(root);
 
     const scoped = files
-        .map((file) => relative(scope, resolve(root, file)))
+        .map((file) => relative(scope, resolve(base, file)))
         .filter((file) => file && !file.startsWith('..') && !isAbsolute(file))
         .map((file) => normalizePath(file as RelativePath));
 

--- a/src/commands/translate/utils/vcs.ts
+++ b/src/commands/translate/utils/vcs.ts
@@ -68,8 +68,30 @@ function gitChangedFiles(root: AbsolutePath, ref: string, runner: VcsRunner) {
     return lines(diff).concat(lines(untracked));
 }
 
+/**
+ * Arc silently returns an empty diff for git range syntax (a..b, a...b),
+ * but supports the same semantics with positional commits:
+ * `arc diff a b` and `arc diff -B a b` (merge-base).
+ * Expand git-style ranges so the same ref value works for both VCS.
+ * An open-ended side of a range means HEAD, as in git.
+ */
+function arcDiffArgs(ref: string) {
+    for (const [separator, extra] of [
+        ['...', ['-B']],
+        ['..', []],
+    ] as [string, string[]][]) {
+        const parts = ref.split(separator);
+
+        if (parts.length === 2) {
+            return [...extra, ...parts.map((part) => part || 'HEAD')];
+        }
+    }
+
+    return [ref];
+}
+
 function arcChangedFiles(root: AbsolutePath, ref: string, runner: VcsRunner) {
-    const diff = runner('arc', ['diff', '--name-only', ref], root);
+    const diff = runner('arc', ['diff', '--name-only', ...arcDiffArgs(ref)], root);
     const status = JSON.parse(runner('arc', ['status', '--json'], root));
     const untracked = ((status?.status?.untracked || []) as ArcStatusEntry[])
         .filter((entry) => entry.type === 'file' && entry.path)

--- a/src/commands/translate/utils/vcs.ts
+++ b/src/commands/translate/utils/vcs.ts
@@ -1,0 +1,115 @@
+import {execFileSync} from 'node:child_process';
+import {realpathSync} from 'node:fs';
+import {isAbsolute, relative, resolve} from 'node:path';
+
+import {normalizePath} from '~/core/utils';
+
+export type VcsRunner = (cmd: string, args: string[], cwd: string) => string;
+
+type VcsInfo = {
+    type: 'git' | 'arc';
+    root: AbsolutePath;
+};
+
+type ArcStatusEntry = {
+    type?: string;
+    path?: string;
+};
+
+const run: VcsRunner = (cmd, args, cwd) => {
+    try {
+        return execFileSync(cmd, args, {cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']});
+    } catch (error) {
+        const stderr = (error as {stderr?: string}).stderr;
+        if (stderr) {
+            (error as Error).message += '\n' + stderr.toString().trim();
+        }
+
+        throw error;
+    }
+};
+
+function lines(output: string) {
+    return output
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+}
+
+function detectVcs(input: AbsolutePath, runner: VcsRunner): VcsInfo {
+    try {
+        const root = runner('git', ['rev-parse', '--show-toplevel'], input).trim();
+
+        return {type: 'git', root: root as AbsolutePath};
+    } catch {
+        // Not a git repository, try arc below.
+    }
+
+    try {
+        const root = runner('arc', ['root'], input).trim();
+
+        return {type: 'arc', root: root as AbsolutePath};
+    } catch {
+        // Not an arc repository either.
+    }
+
+    throw new Error(`Unable to find git or arc repository for ${input}.`);
+}
+
+function gitChangedFiles(root: AbsolutePath, ref: string, runner: VcsRunner) {
+    const quotepath = ['-c', 'core.quotepath=false'];
+    const diff = runner('git', [...quotepath, 'diff', '--name-only', ref], root);
+    const untracked = runner(
+        'git',
+        [...quotepath, 'ls-files', '--others', '--exclude-standard'],
+        root,
+    );
+
+    return lines(diff).concat(lines(untracked));
+}
+
+function arcChangedFiles(root: AbsolutePath, ref: string, runner: VcsRunner) {
+    const diff = runner('arc', ['diff', '--name-only', ref], root);
+    const status = JSON.parse(runner('arc', ['status', '--json'], root));
+    const untracked = ((status?.status?.untracked || []) as ArcStatusEntry[])
+        .filter((entry) => entry.type === 'file' && entry.path)
+        .map((entry) => entry.path as string);
+
+    return lines(diff).concat(untracked);
+}
+
+function realScope(input: AbsolutePath): AbsolutePath {
+    try {
+        return realpathSync(input) as AbsolutePath;
+    } catch {
+        return resolve(input) as AbsolutePath;
+    }
+}
+
+/**
+ * Returns files changed in the current VCS working copy (git or arc),
+ * relative to the input directory.
+ *
+ * Diff is computed against `ref` (HEAD by default).
+ * Untracked files are always included.
+ * Files outside the input directory are dropped.
+ * Deleted files are not filtered here - they are naturally skipped later,
+ * when the result is matched against really existing project files.
+ */
+export function resolveVcsDiffFiles(
+    input: AbsolutePath,
+    ref = 'HEAD',
+    runner: VcsRunner = run,
+): NormalizedPath[] {
+    const {type, root} = detectVcs(input, runner);
+    const files =
+        type === 'git' ? gitChangedFiles(root, ref, runner) : arcChangedFiles(root, ref, runner);
+    const scope = realScope(input);
+
+    const scoped = files
+        .map((file) => relative(scope, resolve(root, file)))
+        .filter((file) => file && !file.startsWith('..') && !isAbsolute(file))
+        .map((file) => normalizePath(file as RelativePath));
+
+    return [...new Set(scoped)];
+}


### PR DESCRIPTION
Implements DOCSTOOLS-6512.

Adds a new `--include-vcs-diff [ref]` option to `yfm translate`:

- Collects files changed in the current VCS working copy and adds them to the translation scope. Both git and arc repositories are supported, detected automatically from the input directory.
- By default the diff is computed against `HEAD`. An optional value sets the ref to diff against: `--include-vcs-diff origin/main`, `--include-vcs-diff trunk`. Untracked files are always included.
- If input is not inside a git or arc repository, the command fails with a clear error.
- If there are no changes (and no other file sources), the command finishes successfully without translation - before any provider is resolved, so no auth is required for the no-op path.
- `--include` is combined with VCS diff files (union). `--exclude` applies to VCS diff files as well.
- Changed paths are matched literally (glob special characters are escaped) and rebased from the repository root to the input directory; files outside input are dropped. Deleted files are naturally skipped since they no longer match any existing project file.

Also fixes multiple `--include` handling in `resolveFiles`: previously a file was kept only if it matched all include patterns at once, so passing two or more `--include` options skipped every file. Now include patterns work as a union. The new option appends one include entry per changed file and relies on this behavior.