### PR TITLE
feat(translate): support --fallback-model for AI providers

### DIFF
--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -385,6 +385,25 @@ describe('Translate command', () => {
                     },
                 );
 
+                test('should disable fallback model by default', '', {
+                    fallbackModel: undefined,
+                });
+
+                test('should handle fallback model arg', '--fallback-model gpt-4o', {
+                    fallbackModel: 'gpt-4o',
+                });
+
+                test(
+                    'should handle fallback model from config',
+                    '',
+                    {
+                        fallbackModel: 'gpt-4o',
+                    },
+                    {
+                        fallbackModel: 'gpt-4o',
+                    },
+                );
+
                 test('should handle api base arg', '--api-base https://llm.internal/v1', {
                     apiBase: 'https://llm.internal/v1',
                 });
@@ -461,6 +480,16 @@ describe('Translate command', () => {
                         model: 'gpt://b1g/yandexgpt/latest',
                     },
                 );
+
+                it('should require folder when fallback model is a short name', async () => {
+                    const instance = await run(
+                        '-o output --source ru --target en --provider yandexgpt --auth y0_test ' +
+                            '--model gpt://b1g/yandexgpt/latest --fallback-model yandexgpt-lite',
+                    );
+
+                    expect(instance.report.code).toBe(1);
+                    expect(instance.provider?.translate).not.toBeCalled();
+                });
 
                 test('should handle folder with short model name', '--folder b1g', {
                     folder: 'b1g',

--- a/src/commands/translate/providers/ai/config.ts
+++ b/src/commands/translate/providers/ai/config.ts
@@ -37,6 +37,17 @@ const model = option({
     `,
 });
 
+const fallbackModel = option({
+    flags: '--fallback-model <value>',
+    desc: `
+        Fallback model identifier in the same format as --model.
+
+        When a request keeps failing after all retries, it is retried with
+        this model on the same provider, credentials and API settings.
+        Auth errors are never retried. Disabled by default.
+    `,
+});
+
 const apiBase = option({
     flags: '--api-base <url>',
     desc: `
@@ -204,6 +215,7 @@ export const options = {
     auth,
     folder,
     model,
+    fallbackModel,
     apiBase,
     apiHeader,
     systemPrompt,

--- a/src/commands/translate/providers/ai/index.ts
+++ b/src/commands/translate/providers/ai/index.ts
@@ -51,6 +51,7 @@ type Args = {
     auth?: string;
     folder?: string;
     model?: string;
+    fallbackModel?: string;
     apiBase?: string;
     apiHeader?: string[];
     systemPrompt?: string;
@@ -74,6 +75,7 @@ type Config = {
     auth: string;
     folder?: string;
     model: string;
+    fallbackModel?: string;
     apiBase?: string;
     apiHeaders: Record<string, string>;
     systemPrompt?: string;
@@ -201,6 +203,7 @@ export class Extension {
                     command
                         .addOption(options.auth)
                         .addOption(options.model)
+                        .addOption(options.fallbackModel)
                         .addOption(options.apiBase)
                         .addOption(options.apiHeader)
                         .addOption(options.systemPrompt)
@@ -244,6 +247,9 @@ export class Extension {
                         DEFAULT_MODELS[providerName];
                     config.model = model;
 
+                    config.fallbackModel =
+                        (defined('fallbackModel', args, config) as string | undefined) || undefined;
+
                     const apiBase =
                         defined('apiBase', args, config) || readEnv(ENV_BASE_URL[providerName]);
                     if (apiBase) {
@@ -259,10 +265,12 @@ export class Extension {
                     if (providerName === 'yandexgpt') {
                         config.folder = defined('folder', args, config);
 
-                        const qualified = model.startsWith('gpt://') || model.startsWith('ds://');
+                        const qualified = (value: string) =>
+                            value.startsWith('gpt://') || value.startsWith('ds://');
+                        const models = [model, config.fallbackModel].filter(Boolean) as string[];
                         ok(
-                            config.folder || qualified,
-                            'Yandex AI Studio: --folder is required when --model is a short name',
+                            config.folder || models.every(qualified),
+                            'Yandex AI Studio: --folder is required when --model or --fallback-model is a short name',
                         );
                     }
 

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -48,6 +48,7 @@ function makeParams(
     client: LLMClient,
     config: Partial<AITranslationConfig> = {},
     store?: TranslationStore,
+    fallbackClient?: LLMClient,
 ) {
     const warn = vi.fn();
     const request = vi.fn();
@@ -58,6 +59,7 @@ function makeParams(
         bytes: 0,
         cached: 0,
         untranslated: 0,
+        fallbackRequests: 0,
     };
     const cache = new Map<string, Defer>();
 
@@ -65,6 +67,7 @@ function makeParams(
         params: {
             store,
             client,
+            fallbackClient,
             config: {
                 userPrompt: '{{fragments}}',
                 promptMode: 'append',
@@ -227,6 +230,68 @@ describe('translate ai provider', () => {
             expect(logger.warn).toHaveBeenCalledWith(
                 'ru/test.md',
                 expect.stringContaining('retried after the main pass'),
+            );
+        });
+
+        it('should translate through the fallback model when the primary keeps failing', async () => {
+            const root = mkdtempSync(join(tmpdir(), 'yfm-ai-fallback-'));
+            const input = join(root, 'docs');
+            const output = join(root, 'out');
+            mkdirSync(join(input, 'ru'), {recursive: true});
+            writeFileSync(join(input, 'ru', 'test.md'), '# Заголовок\n\nПривет, мир.\n');
+
+            const primary: LLMClient = {
+                name: 'fake',
+                complete: vi.fn(async () => {
+                    throw new LLMRateLimitError('Too Many Requests');
+                }),
+            };
+            const fallback = makeFullClient();
+            const factory = vi.fn((config: AITranslationConfig) =>
+                config.model === 'reserve' ? fallback : primary,
+            );
+
+            const provider = new Provider(factory, {} as never);
+            const logger = {
+                translate: vi.fn(),
+                translated: vi.fn(),
+                request: vi.fn(),
+                stat: vi.fn(),
+                warn: vi.fn(),
+                error: vi.fn(),
+            };
+            Object.assign(provider, {logger});
+
+            await provider.translate(['ru/test.md'], {
+                input,
+                output,
+                source: {language: 'ru', locale: 'RU'},
+                target: [{language: 'en', locale: 'US'}],
+                vars: {},
+                dryRun: false,
+                judge: false,
+                model: 'main',
+                fallbackModel: 'reserve',
+                userPrompt: '{{fragments}}',
+                promptMode: 'append',
+                glossaryPairs: [],
+                temperature: 0,
+                maxOutputTokens: 200,
+                maxBatchTokens: 100,
+                maxConcurrency: 2,
+                retry: 0,
+                rateLimitRetry: 0,
+            } as unknown as AITranslationConfig);
+
+            const result = readFileSync(join(output, 'en', 'test.md'), 'utf8');
+            expect(result).toContain('T:Привет, мир.');
+            expect(logger.error).not.toHaveBeenCalled();
+            expect(logger.warn).toHaveBeenCalledWith(
+                'ru/test.md',
+                expect.stringContaining('fallback model'),
+            );
+            expect(logger.stat).toHaveBeenCalledWith(
+                expect.stringContaining('fallback-requests: 1'),
             );
         });
 
@@ -640,6 +705,52 @@ describe('translate ai provider', () => {
             } finally {
                 vi.useRealTimers();
             }
+        });
+
+        it('should switch to the fallback model after the primary retries are exhausted', async () => {
+            const client = makeClient(() => new LLMRateLimitError('Too Many Requests'));
+            const fallback = makeClient(translated);
+            const {params, warn, stat} = makeParams(
+                client,
+                {retry: 0, rateLimitRetry: 0},
+                undefined,
+                fallback,
+            );
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['One']);
+
+            expect(result).toEqual(['T:One']);
+            expect(client.complete).toHaveBeenCalledTimes(1);
+            expect(fallback.complete).toHaveBeenCalledTimes(1);
+            expect(stat.fallbackRequests).toBe(1);
+            expect(warn).toHaveBeenCalledWith('file.md', expect.stringContaining('fallback model'));
+        });
+
+        it('should not use the fallback model for auth errors', async () => {
+            const client = makeClient(() => new LLMAuthError('denied'));
+            const fallback = makeClient(translated);
+            const {params, stat} = makeParams(client, {}, undefined, fallback);
+            const translate = makeTranslator(params);
+
+            await expect(translate('file.md', ['One'])).rejects.toThrow('denied');
+            expect(fallback.complete).not.toHaveBeenCalled();
+            expect(stat.fallbackRequests).toBe(0);
+        });
+
+        it('should rethrow the fallback model error when both models fail', async () => {
+            const client = makeClient(() => new LLMRateLimitError('primary down'));
+            const fallback = makeClient(() => new LLMRateLimitError('fallback down'));
+            const {params, stat} = makeParams(
+                client,
+                {retry: 0, rateLimitRetry: 0},
+                undefined,
+                fallback,
+            );
+            const translate = makeTranslator(params);
+
+            await expect(translate('file.md', ['One'])).rejects.toThrow('fallback down');
+            expect(stat.fallbackRequests).toBe(0);
         });
 
         it('should retry one-by-one when fragment count mismatches', async () => {

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -1,7 +1,7 @@
 import type {Logger} from '~/core/logger';
 import type {TranslateConfig} from '~/commands/translate';
 import type {AITranslationConfig} from './index';
-import type {LLMClient} from './clients/types';
+import type {CompletionResult, LLMClient} from './clients/types';
 import type {JudgePair} from './judge';
 
 import {writeFile} from 'node:fs/promises';
@@ -24,6 +24,7 @@ import {TranslateLogger} from '../../logger';
 
 import {
     Defer,
+    LLMAuthError,
     LLMResponseError,
     RateGate,
     TranslationStore,
@@ -63,6 +64,9 @@ export class Provider {
 
     async translate(files: string[], config: AITranslationConfig) {
         const client = this.clientFactory(config);
+        const fallbackClient = config.fallbackModel
+            ? this.clientFactory({...config, model: config.fallbackModel})
+            : undefined;
         const {input, output, source, target: targets, vars, dryRun, maxConcurrency} = config;
 
         try {
@@ -75,6 +79,7 @@ export class Provider {
                     bytes: 0,
                     cached: 0,
                     untranslated: 0,
+                    fallbackRequests: 0,
                 };
                 const store = makeStore(client, config, source.language, target.language);
 
@@ -82,6 +87,7 @@ export class Provider {
 
                 const translate = makeTranslator({
                     client,
+                    fallbackClient,
                     config,
                     sourceLanguage: source.language,
                     targetLanguage: target.language,
@@ -125,7 +131,8 @@ export class Provider {
                 this.logger.stat(
                     `requests: ${stat.requests} input-tokens: ${stat.inputTokens} ` +
                         `output-tokens: ${stat.outputTokens} bytes: ${stat.bytes} ` +
-                        `cached-units: ${stat.cached} untranslated-units: ${stat.untranslated}`,
+                        `cached-units: ${stat.cached} untranslated-units: ${stat.untranslated}` +
+                        (fallbackClient ? ` fallback-requests: ${stat.fallbackRequests}` : ''),
                 );
 
                 if (pairs.length) {
@@ -426,6 +433,8 @@ function makeProcessor(params: ProcessorParams) {
 
 type TranslatorParams = {
     client: LLMClient;
+    /** Client for --fallback-model, tried after the primary retries are exhausted. */
+    fallbackClient?: LLMClient;
     config: AITranslationConfig;
     sourceLanguage: string;
     targetLanguage: string;
@@ -438,6 +447,7 @@ type TranslatorParams = {
         bytes: number;
         cached: number;
         untranslated: number;
+        fallbackRequests: number;
     };
     logger: TranslateLogger;
 };
@@ -594,7 +604,17 @@ export function normalizeCached(unit: string, stored: string): string {
 }
 
 export function makeTranslator(params: TranslatorParams): Translate {
-    const {client, config, sourceLanguage, targetLanguage, cache, store, stat, logger} = params;
+    const {
+        client,
+        fallbackClient,
+        config,
+        sourceLanguage,
+        targetLanguage,
+        cache,
+        store,
+        stat,
+        logger,
+    } = params;
     const {
         systemPrompt,
         userPrompt,
@@ -611,11 +631,17 @@ export function makeTranslator(params: TranslatorParams): Translate {
 
     const schedule = scheduler(maxConcurrency);
     // One gate per translator: a 429 from any request pauses all of them
-    // until the rate limit window elapses.
+    // until the rate limit window elapses. The fallback model has its own
+    // quota, so its requests must not hold on the primary rate limit window.
     const gate = new RateGate();
+    const fallbackGate = new RateGate();
     const marker = untranslatedMarker(sourceLanguage, targetLanguage);
 
-    async function translateBatch(fragments: string[], context: string): Promise<string[]> {
+    async function translateBatch(
+        path: string,
+        fragments: string[],
+        context: string,
+    ): Promise<string[]> {
         if (!fragments.length) {
             return [];
         }
@@ -643,11 +669,31 @@ export function makeTranslator(params: TranslatorParams): Translate {
             return fragments;
         }
 
-        const result = await backoff(
-            () => client.complete(messages, {temperature, maxTokens: maxOutputTokens}),
-            retry,
-            {rateLimitRetries: rateLimitRetry, gate},
-        );
+        let result: CompletionResult;
+        try {
+            result = await backoff(
+                () => client.complete(messages, {temperature, maxTokens: maxOutputTokens}),
+                retry,
+                {rateLimitRetries: rateLimitRetry, gate},
+            );
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            // Auth errors are fatal and shared with the fallback client:
+            // the same credentials would fail again.
+            if (!fallbackClient || error instanceof LLMAuthError) {
+                throw error;
+            }
+            logger.warn(
+                path,
+                `Primary model failed (${error.message}); retrying with the fallback model.`,
+            );
+            result = await backoff(
+                () => fallbackClient.complete(messages, {temperature, maxTokens: maxOutputTokens}),
+                retry,
+                {rateLimitRetries: rateLimitRetry, gate: fallbackGate},
+            );
+            stat.fallbackRequests++;
+        }
 
         stat.requests++;
         stat.bytes += bytes(fragments);
@@ -683,13 +729,13 @@ export function makeTranslator(params: TranslatorParams): Translate {
         });
     }
 
-    async function translateWithFallback(
+    async function translateWithSplit(
         path: string,
         fragments: string[],
         context: string,
     ): Promise<string[]> {
         try {
-            return await translateBatch(fragments, context);
+            return await translateBatch(path, fragments, context);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (error instanceof LLMResponseError && fragments.length > 1) {
@@ -699,7 +745,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
                 );
                 const result: string[] = [];
                 for (const fragment of fragments) {
-                    const single = await translateBatch([fragment], context);
+                    const single = await translateBatch(path, [fragment], context);
                     result.push(single[0]);
                 }
                 return result;
@@ -727,7 +773,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
                         if (!dryRun) {
                             logger.request(path, `${batch.length} units, ~${batchTokens} tokens`);
                         }
-                        const translated = await translateWithFallback(path, batch, context);
+                        const translated = await translateWithSplit(path, batch, context);
                         translated.forEach((text, i) => {
                             if (!dryRun && text === batch[i] && marker?.test(text)) {
                                 // The model returned source-script text unchanged.

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -98,21 +98,7 @@ export class Provider {
                 });
 
                 const pairs: JudgePair[] = [];
-                const collect =
-                    config.judge && !dryRun
-                        ? (path: string, units: string[], parts: string[]) => {
-                              units.forEach((unit, index) => {
-                                  if (parts[index] === undefined || parts[index] === unit) {
-                                      return;
-                                  }
-                                  pairs.push({
-                                      path,
-                                      source: unwrapUnit(unit).text,
-                                      translation: unwrapUnit(parts[index]).text,
-                                  });
-                              });
-                          }
-                        : undefined;
+                const collect = config.judge && !dryRun ? makeJudgeCollector(pairs) : undefined;
 
                 const processFile = makeProcessor({
                     input,
@@ -374,6 +360,25 @@ export function extractTitle(data: unknown): string | undefined {
 
 function describeDocument(path: string, context?: DocContext): string {
     return context?.title ? `document "${context.title}" (file ${path})` : `file ${path}`;
+}
+
+/**
+ * Collects source/translation pairs for the judge. Units the model left
+ * untranslated are not scored: identity output is a miss, not a translation.
+ */
+function makeJudgeCollector(pairs: JudgePair[]) {
+    return (path: string, units: string[], parts: string[]) => {
+        units.forEach((unit, index) => {
+            if (parts[index] === undefined || parts[index] === unit) {
+                return;
+            }
+            pairs.push({
+                path,
+                source: unwrapUnit(unit).text,
+                translation: unwrapUnit(parts[index]).text,
+            });
+        });
+    };
 }
 
 function makeProcessor(params: ProcessorParams) {


### PR DESCRIPTION
## Что сделано

Новая опция `--fallback-model` (и поле `fallbackModel` в конфиге) для AI-провайдеров `yfm translate` (DOCSTOOLS-6494).

- Когда запрос исчерпал все ретраи (`--retry` / `--rate-limit-retry`), он повторяется с фолбек-моделью на том же провайдере, с теми же кредами и настройками API (`--api-base`, `--api-header` и т.д.). По умолчанию выключено, никаких зашитых моделей.
- У фолбек-модели своя квота, поэтому у неё отдельный rate-gate: окно 429 основной модели не тормозит фолбек-запросы.
- Ошибки авторизации фолбеком не ретраятся - креды общие, повтор бессмыслен.
- В итоговой статистике появляется счётчик `fallback-requests` (только когда фолбек настроен).
- Для yandexgpt проверка `--folder` распространена на короткое имя фолбек-модели.
- Переименован внутренний `translateWithFallback` -> `translateWithSplit`: он про разбиение батча по одному фрагменту, имя конфликтовало с новым фолбеком по модели.