### PR TITLE
feat(translate): support --context-file for AI providers DOCSTOOLS-6493

### DIFF
--- a/src/commands/translate/__tests__/context.md
+++ b/src/commands/translate/__tests__/context.md
@@ -1,0 +1,3 @@
+# Test glossary
+
+- облако -> cloud

--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -430,6 +430,28 @@ describe('Translate command', () => {
                     judgeThreshold: 80,
                 });
 
+                test('should have no context files by default', '', {
+                    contextFiles: [],
+                });
+
+                test(
+                    'should read context file arg',
+                    '--context-file src/commands/translate/__tests__/context.md',
+                    {
+                        // @ts-ignore - asymmetric matcher in expected config
+                        contextFiles: [expect.stringContaining('Test glossary')],
+                    },
+                );
+
+                it('should fail on a missing context file', async () => {
+                    const instance = await run(
+                        '-o output --source ru --target en --provider openai --auth sk-test ' +
+                            '--context-file missing-context.md',
+                    );
+
+                    expect(instance.report.code).toBe(1);
+                });
+
                 test('should resolve cache dir arg', '--cache-dir .translate-cache', {
                     // @ts-ignore - asymmetric matcher in expected config
                     cacheDir: expect.stringContaining('.translate-cache'),

--- a/src/commands/translate/providers/ai/config.ts
+++ b/src/commands/translate/providers/ai/config.ts
@@ -136,6 +136,24 @@ const noCache = option({
     desc: 'Disable the persistent translation cache for this run.',
 });
 
+const contextFile = option({
+    flags: '--context-file <value>',
+    desc: `
+        Additional context for the translation prompt: project info, style guides,
+        UI text lists, terminology notes and other reference materials of arbitrary
+        structure. Repeat the option to pass several sections.
+
+        Accepts a path to a text file (md, json, txt - the content is passed
+        to the model as-is) or a literal multi-line text block.
+
+        Sections are appended to the system prompt. Add the {{contextFiles}}
+        placeholder to --system-prompt or --user-prompt to control placement.
+
+        Config alternative: ${cyan('contextFiles')} list in the yfm config.
+    `,
+    parser: toArray,
+});
+
 const glossaryExample = gray(dedent`
     glossaryPairs:
       - sourceText: string
@@ -212,6 +230,7 @@ export const options = {
     systemPrompt,
     userPrompt,
     promptMode,
+    contextFile,
     glossary,
     judge,
     judgeModel,

--- a/src/commands/translate/providers/ai/index.ts
+++ b/src/commands/translate/providers/ai/index.ts
@@ -1,4 +1,5 @@
 import type {BaseProgram} from '~/core/program';
+import type {Config as ResolvedConfig} from '~/core/config';
 import type {Translate, TranslateArgs, TranslateConfig} from '~/commands/translate';
 import type {LLMClient} from './clients/types';
 import type {GlossaryPair, PromptMode} from './prompts';
@@ -14,7 +15,7 @@ import {own} from '~/core/utils';
 import {Provider} from './provider';
 import {options} from './config';
 import {resolveToken} from './auth';
-import {resolvePromptValue} from './prompts';
+import {resolveContextValue, resolvePromptValue} from './prompts';
 import {YandexGptClient} from './clients/yandexgpt';
 import {AnthropicClient} from './clients/anthropic';
 import {createOpenAIClient, createOpenRouterClient} from './clients/openai';
@@ -66,6 +67,7 @@ type Args = {
     systemPrompt?: string;
     userPrompt?: string;
     promptMode?: PromptMode;
+    contextFile?: string[];
     glossary?: string;
     judge?: boolean;
     judgeModel?: string;
@@ -89,6 +91,7 @@ type Config = {
     systemPrompt?: string;
     userPrompt?: string;
     promptMode: PromptMode;
+    contextFiles: string[];
     glossary?: string;
     glossaryPairs: GlossaryPair[];
     judge: boolean;
@@ -139,6 +142,26 @@ function parseHeaders(value: unknown): Record<string, string> {
     }
 
     return parseHeaders([value]);
+}
+
+/**
+ * Resolves --context-file values: CLI paths from cwd, config values from the config dir.
+ */
+function resolveContextFiles(
+    args: TranslateArgs & Partial<Args>,
+    config: ResolvedConfig<TranslateConfig & Partial<Config>>,
+): string[] {
+    if (own<string[], 'contextFile'>(args, 'contextFile')) {
+        return args.contextFile.map((value) => resolveContextValue(value));
+    }
+
+    if (own<string[] | string, 'contextFiles'>(config, 'contextFiles')) {
+        return ([] as string[])
+            .concat(config.contextFiles)
+            .map((value) => resolveContextValue(value, config.resolve));
+    }
+
+    return [];
 }
 
 function makeClientFactory(provider: ProviderName) {
@@ -216,6 +239,7 @@ export class Extension {
                         .addOption(options.systemPrompt)
                         .addOption(options.userPrompt)
                         .addOption(options.promptMode)
+                        .addOption(options.contextFile)
                         .addOption(options.glossary)
                         .addOption(options.judge)
                         .addOption(options.judgeModel)
@@ -292,6 +316,8 @@ export class Extension {
 
                     config.systemPrompt = resolvePrompt('systemPrompt');
                     config.userPrompt = resolvePrompt('userPrompt');
+
+                    config.contextFiles = resolveContextFiles(args, config);
 
                     config.promptMode =
                         (defined('promptMode', args, config) as PromptMode) || 'append';

--- a/src/commands/translate/providers/ai/prompts.spec.ts
+++ b/src/commands/translate/providers/ai/prompts.spec.ts
@@ -1,6 +1,15 @@
+import {mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {describe, expect, it} from 'vitest';
 
-import {DEFAULT_SYSTEM_PROMPT, FRAGMENT_SEPARATOR, buildMessages, splitFragments} from './prompts';
+import {
+    DEFAULT_SYSTEM_PROMPT,
+    FRAGMENT_SEPARATOR,
+    buildMessages,
+    resolveContextValue,
+    splitFragments,
+} from './prompts';
 
 const config = {
     promptMode: 'append' as const,
@@ -116,6 +125,85 @@ describe('translate ai prompts', () => {
             });
 
             expect(system.content).toContain('You are translating Document context');
+        });
+
+        it('should append context files to the system prompt in order', () => {
+            const [system, user] = buildMessages(['Hello'], {
+                ...config,
+                contextFiles: ['# Project info\n\nDeploy platform.', '# Glossary\n\ncloud'],
+            });
+
+            expect(system.content).toContain('reference materials');
+            expect(system.content).toMatch(/Project info[\s\S]*Glossary/);
+            expect(user.content).not.toContain('Project info');
+        });
+
+        it('should not mention reference materials without context files', () => {
+            const [system] = buildMessages(['Hello'], config);
+
+            expect(system.content).not.toContain('reference materials');
+        });
+
+        it('should respect contextFiles placeholder in a custom system prompt', () => {
+            const [system] = buildMessages(['Hello'], {
+                ...config,
+                promptMode: 'replace',
+                systemPrompt: 'Intro.\n\n{{contextFiles}}\n\nRules.',
+                contextFiles: ['# Glossary'],
+            });
+
+            expect(system.content).toMatch(/Intro\.[\s\S]*# Glossary[\s\S]*Rules\./);
+            expect(system.content).not.toContain('{{contextFiles}}');
+        });
+
+        it('should place context files into the user prompt when referenced there', () => {
+            const [system, user] = buildMessages(['Hello'], {
+                ...config,
+                userPrompt: '{{contextFiles}}\n\n{{fragments}}',
+                contextFiles: ['# Glossary'],
+            });
+
+            expect(user.content).toContain('# Glossary');
+            expect(system.content).not.toContain('# Glossary');
+        });
+
+        it('should drop the placeholder when no context files are configured', () => {
+            const [system] = buildMessages(['Hello'], {
+                ...config,
+                promptMode: 'replace',
+                systemPrompt: 'Intro.\n\n{{contextFiles}}',
+            });
+
+            expect(system.content).not.toContain('{{contextFiles}}');
+        });
+    });
+
+    describe('resolveContextValue', () => {
+        it('should read an existing file', () => {
+            const dir = mkdtempSync(join(tmpdir(), 'translate-context-'));
+            const file = join(dir, 'glossary.md');
+            writeFileSync(file, '# Glossary\n\ncloud\n');
+
+            expect(resolveContextValue(file)).toBe('# Glossary\n\ncloud\n');
+        });
+
+        it('should resolve a relative path with the resolve callback', () => {
+            const dir = mkdtempSync(join(tmpdir(), 'translate-context-'));
+            writeFileSync(join(dir, 'info.md'), 'Project info.');
+
+            expect(resolveContextValue('info.md', (path) => join(dir, path))).toBe('Project info.');
+        });
+
+        it('should pass a multi-line value through as a literal', () => {
+            expect(resolveContextValue('Use these terms:\n- cloud')).toBe(
+                'Use these terms:\n- cloud',
+            );
+        });
+
+        it('should fail on a missing file path', () => {
+            expect(() => resolveContextValue('missing-context.md')).toThrow(
+                'Context file not found',
+            );
         });
     });
 });

--- a/src/commands/translate/providers/ai/prompts.spec.ts
+++ b/src/commands/translate/providers/ai/prompts.spec.ts
@@ -194,6 +194,15 @@ describe('translate ai prompts', () => {
             expect(resolveContextValue('info.md', (path) => join(dir, path))).toBe('Project info.');
         });
 
+        it('should not fall back to cwd when the resolve callback is provided', () => {
+            const dir = mkdtempSync(join(tmpdir(), 'translate-context-'));
+
+            // package.json exists in cwd, but config values resolve from the config dir only.
+            expect(() => resolveContextValue('package.json', (path) => join(dir, path))).toThrow(
+                'Context file not found',
+            );
+        });
+
         it('should pass a multi-line value through as a literal', () => {
             expect(resolveContextValue('Use these terms:\n- cloud')).toBe(
                 'Use these terms:\n- cloud',

--- a/src/commands/translate/providers/ai/prompts.ts
+++ b/src/commands/translate/providers/ai/prompts.ts
@@ -1,5 +1,6 @@
 import type {ChatMessage} from './clients/types';
 
+import {ok} from 'node:assert';
 import {existsSync, readFileSync} from 'node:fs';
 import {dedent} from 'ts-dedent';
 
@@ -16,6 +17,8 @@ export type PromptConfig = {
     glossaryPairs: GlossaryPair[];
     /** Human-readable document context, e.g. `document "Quickstart" (file docs/ru/index.md)`. */
     context?: string;
+    /** Resolved contents of --context-file values, injected as reference material. */
+    contextFiles?: string[];
 };
 
 const FRAGMENT_SEPARATOR = '<<<§§§>>>';
@@ -77,6 +80,43 @@ export function resolvePromptValue(
     return value;
 }
 
+/**
+ * Resolves a --context-file value: a path to a text file or a literal
+ * multi-line text block. Unlike prompts, a single-line value is always
+ * a path, so a missing file is a configuration error, not a literal.
+ */
+export function resolveContextValue(value: string, resolve?: (path: string) => string): string {
+    const trimmed = value.trim();
+
+    // A real file path never contains a line break.
+    if (!trimmed.includes('\n')) {
+        if (existsSync(trimmed)) {
+            return readFileSync(trimmed, 'utf8');
+        }
+
+        if (resolve) {
+            const resolved = resolve(trimmed);
+            if (existsSync(resolved)) {
+                return readFileSync(resolved, 'utf8');
+            }
+        }
+
+        ok(false, `Context file not found: ${value}`);
+    }
+
+    return value;
+}
+
+const CONTEXT_FILES_PREAMBLE = 'Use the following reference materials for this translation:';
+
+function renderContextFiles(sections: string[]): string {
+    const items = sections.map((section) => section.trim()).filter(Boolean);
+    if (!items.length) {
+        return '';
+    }
+    return [CONTEXT_FILES_PREAMBLE, ...items].join('\n\n');
+}
+
 function applyVars(template: string, vars: Record<string, string>): string {
     return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
         return key in vars ? vars[key] : match;
@@ -110,36 +150,49 @@ export function splitFragments(text: string): string[] {
  * `promptMode`:
  *  - `append` (default): combines the default system prompt with the user-provided system prompt.
  *  - `replace`: the user-provided system prompt fully replaces the default.
+ *
+ * Context files land in the system prompt: they are identical for every
+ * batch, and a static system prompt plays well with provider-side prompt
+ * caching. A `{{contextFiles}}` placeholder in either prompt overrides
+ * the default placement.
  */
 export function buildMessages(fragments: string[], config: PromptConfig): ChatMessage[] {
     const {systemPrompt, userPrompt, promptMode, sourceLanguage, targetLanguage, glossaryPairs} =
         config;
 
     const joined = joinFragments(fragments);
+    const contextFiles = renderContextFiles(config.contextFiles || []);
     const vars = {
         source: sourceLanguage,
         target: targetLanguage,
         glossary: renderGlossary(glossaryPairs),
         context: config.context ? `Document context: ${config.context}.` : '',
+        contextFiles,
         separator: FRAGMENT_SEPARATOR,
         fragments: joined,
         text: joined,
     };
 
-    let system: string;
+    let systemTemplate: string;
     if (promptMode === 'replace' && systemPrompt) {
-        system = applyVars(systemPrompt, vars);
+        systemTemplate = systemPrompt;
     } else if (systemPrompt) {
-        system = applyVars(DEFAULT_SYSTEM_PROMPT, vars) + '\n\n' + applyVars(systemPrompt, vars);
+        systemTemplate = DEFAULT_SYSTEM_PROMPT + '\n\n' + systemPrompt;
     } else {
-        system = applyVars(DEFAULT_SYSTEM_PROMPT, vars);
+        systemTemplate = DEFAULT_SYSTEM_PROMPT;
     }
 
     const userTemplate = userPrompt || DEFAULT_USER_PROMPT;
-    const user = applyVars(userTemplate, vars);
+
+    const placed = [systemTemplate, userTemplate].some((template) =>
+        template.includes('{{contextFiles}}'),
+    );
+    if (contextFiles && !placed) {
+        systemTemplate += '\n\n{{contextFiles}}';
+    }
 
     return [
-        {role: 'system', content: system},
-        {role: 'user', content: user},
+        {role: 'system', content: applyVars(systemTemplate, vars)},
+        {role: 'user', content: applyVars(userTemplate, vars)},
     ];
 }

--- a/src/commands/translate/providers/ai/prompts.ts
+++ b/src/commands/translate/providers/ai/prompts.ts
@@ -84,21 +84,19 @@ export function resolvePromptValue(
  * Resolves a --context-file value: a path to a text file or a literal
  * multi-line text block. Unlike prompts, a single-line value is always
  * a path, so a missing file is a configuration error, not a literal.
+ *
+ * The `resolve` callback is the only base when provided: config values
+ * must not silently pick up a same-named file from the process cwd.
  */
 export function resolveContextValue(value: string, resolve?: (path: string) => string): string {
     const trimmed = value.trim();
 
     // A real file path never contains a line break.
     if (!trimmed.includes('\n')) {
-        if (existsSync(trimmed)) {
-            return readFileSync(trimmed, 'utf8');
-        }
+        const path = resolve ? resolve(trimmed) : trimmed;
 
-        if (resolve) {
-            const resolved = resolve(trimmed);
-            if (existsSync(resolved)) {
-                return readFileSync(resolved, 'utf8');
-            }
+        if (existsSync(path)) {
+            return readFileSync(path, 'utf8');
         }
 
         ok(false, `Context file not found: ${value}`);

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -476,6 +476,8 @@ export function makeStore(
         defaultSystemPrompt: DEFAULT_SYSTEM_PROMPT,
         defaultUserPrompt: DEFAULT_USER_PROMPT,
         glossaryPairs: config.glossaryPairs,
+        // Only when configured, so existing caches survive the CLI update.
+        ...(config.contextFiles?.length ? {contextFiles: config.contextFiles} : {}),
     });
 
     return new TranslationStore(file, fingerprint);
@@ -600,6 +602,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
         userPrompt,
         promptMode,
         glossaryPairs,
+        contextFiles,
         temperature,
         maxOutputTokens,
         maxBatchTokens,
@@ -630,6 +633,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
                 sourceLanguage,
                 targetLanguage,
                 glossaryPairs,
+                contextFiles,
                 context,
             },
         );


### PR DESCRIPTION
## Overview

`yfm translate` now accepts arbitrary reference materials for the translation prompt: project descriptions, style guides, UI text lists, terminology tables and other context of arbitrary structure. Real translation pipelines carry glossaries as markdown tables with definitions and free-form style guides - none of which fit the strict `--glossary` YAML pairs.

## Details

- New repeatable `--context-file <value>` option (config alternative: `contextFiles` list in the yfm config). Accepts a path to a text file (md, json, txt - the content is passed to the model as-is) or a literal multi-line text block.
- By default sections are appended to the system prompt: they are identical for every batch, and a static system prompt plays well with provider-side prompt caching. A `{{contextFiles}}` placeholder in `--system-prompt` or `--user-prompt` overrides the placement.
- Unlike prompts, a single-line value that does not resolve to an existing file is a configuration error, not a literal: a typo in a path must not silently become prompt text.
- Context content participates in the translation cache fingerprint, so editing a context file safely resets the cache. The fingerprint stays unchanged when no context files are configured, existing caches survive the update.

## Config usage

The main consumer is CI, where translation parameters live in the docs repo rather than in the pipeline: the `translate` section of the `.yfm` at the input root is picked up automatically, and relative paths are resolved from the `.yfm` location.

```yaml
translate:
  contextFiles:
    - ./neurotranslate/project_info.md
    - ./neurotranslate/glossary.md
    - ./neurotranslate/ui_elements_list.md
```

Credentials stay out of the config by design: `--auth` is accepted only as a flag or environment variable.
