### PR TITLE
feat(translate): seed the translation cache from existing translations

### DIFF
--- a/src/commands/translate/commands/seed.command.spec.ts
+++ b/src/commands/translate/commands/seed.command.spec.ts
@@ -1,0 +1,92 @@
+import {mkdirSync, mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {parse} from '~/commands/parser';
+
+import {SeedStore, seedFilePath} from '../providers/ai/utils';
+import {loadTranslationUnits} from '../utils';
+import {Run} from '../run';
+
+import {Seed} from './seed';
+
+function project(files: Record<string, string>) {
+    const dir = mkdtempSync(join(tmpdir(), 'yfm-seed-command-')) as AbsolutePath;
+    for (const [path, content] of Object.entries(files)) {
+        mkdirSync(dirname(join(dir, path)), {recursive: true});
+        writeFileSync(join(dir, path), content);
+    }
+    return dir;
+}
+
+async function runSeed(argv: string, files: string[]) {
+    const seed = new Seed();
+
+    vi.spyOn(Run.prototype, 'prepareRun').mockImplementation(async () => undefined);
+    vi.spyOn(Run.prototype, 'getFiles').mockResolvedValue([files, []]);
+
+    const rawArgs = ['node', 'index'].concat(argv.split(' '));
+    const args = parse(rawArgs, 'seed');
+
+    await seed.init(args);
+    await seed.parse(rawArgs);
+
+    return seed;
+}
+
+describe('Translate.Seed command', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should seed the cache from CLI arguments', async () => {
+        const input = project({
+            'ru/article.md': 'Первое. Второе.\n',
+            'en/article.md': 'First. Second.\n',
+            'ru/drift.md': 'Одно.\n',
+            'en/drift.md': 'One. Extra.\n',
+        });
+        const cacheDir = mkdtempSync(join(tmpdir(), 'yfm-seed-command-cache-')) as AbsolutePath;
+
+        await runSeed(`-i ${input} --source ru --target en --cache-dir ${cacheDir}`, [
+            'ru/article.md',
+            'ru/drift.md',
+        ]);
+
+        const seeds = new SeedStore(seedFilePath(cacheDir, 'ru', 'en'));
+        seeds.load();
+
+        const {units} = await loadTranslationUnits({
+            inputPath: join(input, 'ru/article.md') as AbsolutePath,
+            path: 'ru/article.md',
+            sourceLanguage: 'ru',
+            targetLanguage: 'en',
+            vars: {},
+        });
+
+        expect(seeds.get(units[0])).toContain('First.');
+        expect(seeds.get(units[1])).toContain('Second.');
+
+        // The drifted file is skipped, so its units are not in the store.
+        const drifted = await loadTranslationUnits({
+            inputPath: join(input, 'ru/drift.md') as AbsolutePath,
+            path: 'ru/drift.md',
+            sourceLanguage: 'ru',
+            targetLanguage: 'en',
+            vars: {},
+        });
+
+        expect(seeds.get(drifted.units[0])).toBeUndefined();
+    });
+
+    it('should require the --cache-dir option', async () => {
+        const input = project({
+            'ru/article.md': 'Первое.\n',
+        });
+
+        await expect(
+            runSeed(`-i ${input} --source ru --target en`, ['ru/article.md']),
+        ).rejects.toThrow('--cache-dir');
+    });
+});

--- a/src/commands/translate/commands/seed.spec.ts
+++ b/src/commands/translate/commands/seed.spec.ts
@@ -1,0 +1,205 @@
+import type {TranslateLogger} from '../logger';
+import type {AITranslationConfig} from '../providers/ai';
+import type {LLMClient} from '../providers/ai/clients/types';
+import type {Defer} from '../providers/ai/utils';
+
+import {mkdirSync, mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {describe, expect, it, vi} from 'vitest';
+
+import {makeStore, makeTranslator} from '../providers/ai/provider';
+import {SeedStore, seedFilePath} from '../providers/ai/utils';
+import {loadTranslationUnits} from '../utils';
+
+import {seedTranslations} from './seed';
+
+function project(files: Record<string, string>) {
+    const dir = mkdtempSync(join(tmpdir(), 'yfm-translate-seed-')) as AbsolutePath;
+    for (const [path, content] of Object.entries(files)) {
+        mkdirSync(dirname(join(dir, path)), {recursive: true});
+        writeFileSync(join(dir, path), content);
+    }
+    return dir;
+}
+
+function loadSeeds(cacheDir: AbsolutePath) {
+    const seeds = new SeedStore(seedFilePath(cacheDir, 'ru', 'en'));
+    seeds.load();
+    return seeds;
+}
+
+const cache = () => mkdtempSync(join(tmpdir(), 'yfm-seed-cache-')) as AbsolutePath;
+
+describe('translate seed', () => {
+    describe('seedTranslations', () => {
+        it('should seed pairs from aligned source and target files', async () => {
+            const input = project({
+                'ru/article.md': '# Заголовок\n\nПервое. Второе.\n',
+                'en/article.md': '# Title\n\nFirst. Second.\n',
+            });
+            const cacheDir = cache();
+
+            const stats = await seedTranslations({
+                input,
+                files: ['ru/article.md'],
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+                cacheDir,
+            });
+
+            expect(stats.seededFiles).toBe(1);
+            expect(stats.seededUnits).toBe(3);
+            expect(stats.mismatched).toEqual([]);
+            expect(stats.missingTargets).toEqual([]);
+
+            const seeds = loadSeeds(cacheDir);
+            const {units} = await loadTranslationUnits({
+                inputPath: join(input, 'ru/article.md') as AbsolutePath,
+                path: 'ru/article.md',
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+            });
+
+            expect(seeds.get(units[0])).toContain('Title');
+            expect(seeds.get(units[1])).toContain('First.');
+            expect(seeds.get(units[2])).toContain('Second.');
+        });
+
+        it('should report files without an existing translation', async () => {
+            const input = project({
+                'ru/new.md': 'Новый файл.\n',
+            });
+            const cacheDir = cache();
+
+            const stats = await seedTranslations({
+                input,
+                files: ['ru/new.md'],
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+                cacheDir,
+            });
+
+            expect(stats.seededFiles).toBe(0);
+            expect(stats.missingTargets).toEqual(['ru/new.md']);
+        });
+
+        it('should not seed files whose unit counts diverge', async () => {
+            const input = project({
+                'ru/drift.md': 'Первое. Второе.\n',
+                'en/drift.md': 'First. Second. Third.\n',
+            });
+            const cacheDir = cache();
+
+            const stats = await seedTranslations({
+                input,
+                files: ['ru/drift.md'],
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+                cacheDir,
+            });
+
+            expect(stats.seededFiles).toBe(0);
+            expect(stats.seededUnits).toBe(0);
+            expect(stats.mismatched).toEqual(['ru/drift.md']);
+        });
+
+        it('should let a translate run reuse seeds without calling the LLM', async () => {
+            const input = project({
+                'ru/article.md': '# Заголовок\n\nПервое. Второе.\n',
+                'en/article.md': '# Title\n\nFirst. Second.\n',
+            });
+            const cacheDir = cache();
+
+            await seedTranslations({
+                input,
+                files: ['ru/article.md'],
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+                cacheDir,
+            });
+
+            const client: LLMClient = {
+                name: 'fake',
+                complete: vi.fn(async () => {
+                    throw new Error('the LLM must not be called for seeded units');
+                }),
+            };
+            const config = {
+                cacheDir,
+                model: 'model',
+                promptMode: 'append',
+                glossaryPairs: [],
+                temperature: 0,
+                maxOutputTokens: 100,
+                maxBatchTokens: 2000,
+                maxConcurrency: 2,
+                retry: 0,
+                dryRun: false,
+            } as unknown as AITranslationConfig;
+
+            const store = makeStore(client, config, 'ru', 'en');
+            store?.load();
+
+            const stat = {
+                inputTokens: 0,
+                outputTokens: 0,
+                requests: 0,
+                bytes: 0,
+                cached: 0,
+                untranslated: 0,
+                fallbackRequests: 0,
+            };
+            const translate = makeTranslator({
+                client,
+                config,
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                cache: new Map<string, Defer>(),
+                store,
+                stat,
+                logger: {warn: vi.fn(), request: vi.fn()} as unknown as TranslateLogger,
+            });
+
+            const {units} = await loadTranslationUnits({
+                inputPath: join(input, 'ru/article.md') as AbsolutePath,
+                path: 'ru/article.md',
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+            });
+
+            const parts = await translate('ru/article.md', units);
+
+            expect(client.complete).not.toHaveBeenCalled();
+            expect(stat.cached).toBe(units.length);
+            expect(parts.join('\n')).toContain('Title');
+            expect(parts.join('\n')).toContain('First.');
+        });
+
+        it('should skip untranslated leftovers instead of freezing them', async () => {
+            const input = project({
+                'ru/mixed.md': 'Переведённое. Забытое.\n',
+                'en/mixed.md': 'Translated. Забытое.\n',
+            });
+            const cacheDir = cache();
+
+            const stats = await seedTranslations({
+                input,
+                files: ['ru/mixed.md'],
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+                cacheDir,
+            });
+
+            expect(stats.seededUnits).toBe(1);
+            expect(stats.skippedUnits).toBe(1);
+        });
+    });
+});

--- a/src/commands/translate/commands/seed.spec.ts
+++ b/src/commands/translate/commands/seed.spec.ts
@@ -37,12 +37,15 @@ describe('translate seed', () => {
             const input = project({
                 'ru/article.md': '# Заголовок\n\nПервое. Второе.\n',
                 'en/article.md': '# Title\n\nFirst. Second.\n',
+                'ru/empty.md': '',
+                'en/empty.md': '',
             });
             const cacheDir = cache();
 
             const stats = await seedTranslations({
                 input,
-                files: ['ru/article.md'],
+                // The empty file has nothing to seed and is silently passed by.
+                files: ['ru/article.md', 'ru/empty.md'],
                 sourceLanguage: 'ru',
                 targetLanguage: 'en',
                 vars: {},

--- a/src/commands/translate/commands/seed.ts
+++ b/src/commands/translate/commands/seed.ts
@@ -1,0 +1,264 @@
+import type {BaseArgs} from '~/core/program';
+import type {Locale} from '../utils';
+import type {ConfigDefaults} from '../utils/config';
+
+import {existsSync} from 'node:fs';
+import {join, relative, resolve} from 'node:path';
+import {pick} from 'lodash';
+import {asyncify, eachLimit} from 'async';
+
+import {YFM_CONFIG_FILENAME} from '~/constants';
+import {Command, defined} from '~/core/config';
+import {
+    BaseProgram,
+    getHooks as getBaseHooks,
+    withConfigDefaults,
+    withConfigScope,
+} from '~/core/program';
+
+import {options} from '../config';
+import {TranslateLogger} from '../logger';
+import {SkipTranslation, TranslateError, languageRepath, loadTranslationUnits} from '../utils';
+import {SeedStore, collectSeedPairs, seedFilePath} from '../providers/ai/utils';
+import {options as aiOptions} from '../providers/ai/config';
+import {untranslatedMarker} from '../providers/ai/provider';
+import {Run} from '../run';
+import {configDefaults, resolveSource, resolveTargets, resolveVars} from '../utils/config';
+
+import {getHooks, withHooks} from './hooks';
+
+const MAX_CONCURRENCY = 50;
+
+export type SeedParams = {
+    input: AbsolutePath;
+    /** Input-relative paths of source language files. */
+    files: string[];
+    sourceLanguage: string;
+    targetLanguage: string;
+    vars: Hash;
+    cacheDir: AbsolutePath;
+};
+
+export type SeedStats = {
+    seededFiles: number;
+    seededUnits: number;
+    skippedUnits: number;
+    missingTargets: string[];
+    mismatched: string[];
+};
+
+/**
+ * Derives translation cache seeds from existing target files.
+ *
+ * For every source file whose translation exists, both sides are split
+ * into units the same way the translate run does; positionally aligned
+ * pairs become cache entries, so a following translate run reuses the
+ * existing translations and only sends changed units to the LLM.
+ */
+export async function seedTranslations(params: SeedParams): Promise<SeedStats> {
+    const {input, files, sourceLanguage, targetLanguage, vars, cacheDir} = params;
+
+    const inputRoot = resolve(input);
+    const repath = languageRepath({
+        inputRoot,
+        outputRoot: inputRoot,
+        sourceLanguage,
+        targetLanguage,
+    });
+    const marker = untranslatedMarker(sourceLanguage, targetLanguage);
+    const seeds = new SeedStore(seedFilePath(cacheDir, sourceLanguage, targetLanguage));
+
+    const stats: SeedStats = {
+        seededFiles: 0,
+        seededUnits: 0,
+        skippedUnits: 0,
+        missingTargets: [],
+        mismatched: [],
+    };
+
+    await eachLimit(
+        files,
+        MAX_CONCURRENCY,
+        asyncify(async (file: string) => {
+            const inputPath = join(inputRoot, file) as AbsolutePath;
+            const targetPath = repath(inputPath) as AbsolutePath;
+
+            if (!existsSync(targetPath)) {
+                stats.missingTargets.push(file);
+                return;
+            }
+
+            const source = await loadTranslationUnits({
+                inputPath,
+                path: file,
+                sourceLanguage,
+                targetLanguage,
+                vars,
+            });
+
+            if (!source.units.length) {
+                return;
+            }
+
+            const target = await loadTranslationUnits({
+                inputPath: targetPath,
+                path: relative(inputRoot, targetPath),
+                sourceLanguage: targetLanguage,
+                targetLanguage: sourceLanguage,
+                vars,
+            });
+
+            const result = collectSeedPairs(source.units, target.units, marker);
+
+            if (result.status === 'mismatch') {
+                stats.mismatched.push(file);
+                return;
+            }
+
+            for (const [sourceUnit, targetUnit] of result.pairs) {
+                seeds.set(sourceUnit, targetUnit);
+            }
+
+            stats.seededFiles++;
+            stats.seededUnits += result.pairs.length;
+            stats.skippedUnits += result.skipped;
+        }),
+    );
+
+    seeds.flush();
+
+    return stats;
+}
+
+export type SeedArgs = BaseArgs & {
+    source?: string;
+    target?: string | string[];
+    include?: string[];
+    exclude?: string[];
+    vars?: Hash;
+    cacheDir: string;
+};
+
+export type SeedConfig = Pick<BaseArgs, 'input' | 'strict' | 'quiet'> & {
+    /** Not configurable: Run requires it, seeding never writes there. */
+    output: AbsolutePath;
+    source: Locale;
+    target: Locale[];
+    include: string[];
+    exclude: string[];
+    files: string[];
+    skipped: [string, string][];
+    vars: Hash;
+    cacheDir: AbsolutePath;
+} & ConfigDefaults;
+
+@withHooks
+@withConfigScope('translate.seed', {strict: true})
+@withConfigDefaults(() => configDefaults())
+export class Seed extends BaseProgram<SeedConfig, SeedArgs> {
+    readonly name = 'Translate.Seed';
+
+    readonly command = new Command('seed').description(
+        'Populate the translation cache from existing target files.',
+    );
+
+    readonly options = [
+        options.input('./'),
+        options.source,
+        options.target,
+        options.files,
+        options.include,
+        options.exclude,
+        options.vars,
+        options.config(YFM_CONFIG_FILENAME),
+        aiOptions.cacheDir,
+    ];
+
+    readonly logger = new TranslateLogger();
+
+    private run!: Run;
+
+    apply(program?: BaseProgram) {
+        super.apply(program);
+
+        getBaseHooks(this).Config.tap('Translate.Seed', (config, args) => {
+            const {input, quiet, strict} = pick(args, ['input', 'quiet', 'strict']) as SeedArgs;
+            const source = resolveSource(config, args);
+            const target = resolveTargets(config, args);
+            const include = defined('include', args, config) || [];
+            const exclude = defined('exclude', args, config) || [];
+            const files = defined('files', args, config) || [];
+            const vars = resolveVars(config, args);
+            const cacheDir = defined('cacheDir', args, config);
+
+            if (!cacheDir) {
+                throw new TranslateError('Required option --cache-dir is not defined', 'CONFIG');
+            }
+
+            return Object.assign(config, {
+                input,
+                output: input,
+                quiet,
+                strict,
+                source,
+                target,
+                files,
+                include,
+                exclude,
+                vars,
+                cacheDir: resolve(cacheDir),
+            });
+        });
+    }
+
+    async action() {
+        const {input, source, target: targets, vars, cacheDir} = this.config;
+
+        this.logger.setup(this.config);
+
+        this.run = new Run(this.config);
+
+        await getBaseHooks(this).BeforeAnyRun.promise(this.run);
+        await getHooks(this).BeforeRun.promise(this.run);
+
+        await this.run.prepareRun();
+
+        const [files, skipped] = await this.run.getFiles();
+
+        this.logger.skipped(skipped);
+
+        for (const target of targets) {
+            try {
+                const stats = await seedTranslations({
+                    input,
+                    files: Array.from(files),
+                    sourceLanguage: source.language,
+                    targetLanguage: target.language,
+                    vars,
+                    cacheDir,
+                });
+
+                for (const file of stats.mismatched) {
+                    this.logger.warn(
+                        file,
+                        'Unit counts diverge between source and translation; the file was not seeded.',
+                    );
+                }
+
+                this.logger.stat(
+                    `${source.language}-${target.language} ` +
+                        `seeded-files: ${stats.seededFiles} seeded-units: ${stats.seededUnits} ` +
+                        `skipped-units: ${stats.skippedUnits} ` +
+                        `missing-targets: ${stats.missingTargets.length} ` +
+                        `mismatched: ${stats.mismatched.length}`,
+                );
+            } catch (error) {
+                if (error instanceof SkipTranslation) {
+                    this.logger.skipped([[error.reason, '']]);
+                    continue;
+                }
+                throw error;
+            }
+        }
+    }
+}

--- a/src/commands/translate/commands/seed.ts
+++ b/src/commands/translate/commands/seed.ts
@@ -18,7 +18,7 @@ import {
 
 import {options} from '../config';
 import {TranslateLogger} from '../logger';
-import {SkipTranslation, TranslateError, languageRepath, loadTranslationUnits} from '../utils';
+import {TranslateError, languageRepath, loadTranslationUnits} from '../utils';
 import {SeedStore, collectSeedPairs, seedFilePath} from '../providers/ai/utils';
 import {options as aiOptions} from '../providers/ai/config';
 import {untranslatedMarker} from '../providers/ai/provider';
@@ -228,37 +228,29 @@ export class Seed extends BaseProgram<SeedConfig, SeedArgs> {
         this.logger.skipped(skipped);
 
         for (const target of targets) {
-            try {
-                const stats = await seedTranslations({
-                    input,
-                    files: Array.from(files),
-                    sourceLanguage: source.language,
-                    targetLanguage: target.language,
-                    vars,
-                    cacheDir,
-                });
+            const stats = await seedTranslations({
+                input,
+                files: Array.from(files),
+                sourceLanguage: source.language,
+                targetLanguage: target.language,
+                vars,
+                cacheDir,
+            });
 
-                for (const file of stats.mismatched) {
-                    this.logger.warn(
-                        file,
-                        'Unit counts diverge between source and translation; the file was not seeded.',
-                    );
-                }
-
-                this.logger.stat(
-                    `${source.language}-${target.language} ` +
-                        `seeded-files: ${stats.seededFiles} seeded-units: ${stats.seededUnits} ` +
-                        `skipped-units: ${stats.skippedUnits} ` +
-                        `missing-targets: ${stats.missingTargets.length} ` +
-                        `mismatched: ${stats.mismatched.length}`,
+            for (const file of stats.mismatched) {
+                this.logger.warn(
+                    file,
+                    'Unit counts diverge between source and translation; the file was not seeded.',
                 );
-            } catch (error) {
-                if (error instanceof SkipTranslation) {
-                    this.logger.skipped([[error.reason, '']]);
-                    continue;
-                }
-                throw error;
             }
+
+            this.logger.stat(
+                `${source.language}-${target.language} ` +
+                    `seeded-files: ${stats.seededFiles} seeded-units: ${stats.seededUnits} ` +
+                    `skipped-units: ${stats.skippedUnits} ` +
+                    `missing-targets: ${stats.missingTargets.length} ` +
+                    `mismatched: ${stats.mismatched.length}`,
+            );
         }
     }
 }

--- a/src/commands/translate/index.ts
+++ b/src/commands/translate/index.ts
@@ -18,6 +18,7 @@ import {getHooks, withHooks} from './hooks';
 import {DESCRIPTION, NAME, options} from './config';
 import {Extract} from './commands/extract';
 import {Compose} from './commands/compose';
+import {Seed} from './commands/seed';
 import {Extension as YandexTranslation} from './providers/yandex';
 import {Extension as AITranslation} from './providers/ai';
 import {copyAssets, resolveSource, resolveTargets, resolveVars} from './utils';
@@ -91,9 +92,12 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
 
     readonly compose = new Compose();
 
+    readonly seed = new Seed();
+
     protected readonly modules: ICallable[] = [
         this.extract,
         this.compose,
+        this.seed,
         new YandexTranslation(),
         new AITranslation(),
         new ExtractOpenapiIncluderFakeExtension(),

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -18,7 +18,14 @@ import {
     unwrapUnit,
 } from './provider';
 import {FRAGMENT_SEPARATOR, splitFragments} from './prompts';
-import {LLMAuthError, LLMRateLimitError, TranslationStore, cacheFingerprint} from './utils';
+import {
+    LLMAuthError,
+    LLMRateLimitError,
+    SeedStore,
+    TranslationStore,
+    cacheFingerprint,
+    seedFilePath,
+} from './utils';
 
 type FakeComplete = (fragments: string[], call: number) => string[] | Error;
 
@@ -409,6 +416,26 @@ describe('translate ai provider', () => {
             store?.flush();
 
             expect(existsSync(join(dir, 'fake.gpt-b1g-yandexgpt-latest.ru-en.json'))).toBe(true);
+        });
+
+        it('should pick up seeds for the language pair from the cache dir', () => {
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const seeds = new SeedStore(seedFilePath(dir, 'ru', 'en'));
+            seeds.set('Привет', 'Hello');
+            seeds.flush();
+
+            const client = makeClient(translated);
+            const config = {
+                cacheDir: dir,
+                model: 'model',
+                promptMode: 'append',
+                glossaryPairs: [],
+            } as unknown as AITranslationConfig;
+
+            const store = makeStore(client, config, 'ru', 'en');
+            store?.load();
+
+            expect(store?.get('Привет')).toBe('Hello');
         });
 
         it('should keep separate caches per model', () => {

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -7,19 +7,11 @@ import type {JudgePair} from './judge';
 import {writeFile} from 'node:fs/promises';
 import {extname, join, resolve} from 'node:path';
 import {asyncify, eachLimit} from 'async';
-import liquid from '@diplodoc/transform/lib/liquid';
 
 import {LogLevel} from '~/core/logger';
 import {isFenceClose, matchFenceOpen} from '~/core/utils';
 
-import {
-    FileLoader,
-    TranslateError,
-    compose,
-    extract,
-    languageRepath,
-    resolveSchemas,
-} from '../../utils';
+import {TranslateError, compose, languageRepath, loadTranslationUnits} from '../../utils';
 import {TranslateLogger} from '../../logger';
 
 import {
@@ -27,11 +19,13 @@ import {
     LLMAuthError,
     LLMResponseError,
     RateGate,
+    SeedStore,
     TranslationStore,
     backoff,
     bytes,
     cacheFingerprint,
     estimateTokens,
+    seedFilePath,
 } from './utils';
 import {DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT, buildMessages, splitFragments} from './prompts';
 import {judgeTranslations} from './judge';
@@ -395,34 +389,15 @@ function makeProcessor(params: ProcessorParams) {
         const inputPath = join(inputRoot, path);
         const outputPath = languageRepath({inputRoot, outputRoot, sourceLanguage, targetLanguage});
 
-        const content = new FileLoader(inputPath);
-        await content.load();
-
-        if (Object.keys(vars).length && content.isString) {
-            content.set(
-                liquid(content.data as string, vars, inputPath, {
-                    conditions: 'strict',
-                    substitutions: false,
-                    cycles: false,
-                }),
-            );
-        }
-
-        if (!content.data) {
-            await content.dump(outputPath);
-            return;
-        }
-
-        const {schemas, ajvOptions} = await resolveSchemas({content: content.data, path});
-        const {units, skeleton} = extract(content.data, {
-            compact: true,
-            source: {language: sourceLanguage, locale: 'RU'},
-            target: {language: targetLanguage, locale: 'US'},
-            schemas,
-            ajvOptions,
+        const {content, units, skeleton, schemas, ajvOptions} = await loadTranslationUnits({
+            inputPath,
+            path,
+            sourceLanguage,
+            targetLanguage,
+            vars,
         });
 
-        if (!units.length) {
+        if (!content.data || !units.length) {
             await content.dump(outputPath);
             return;
         }
@@ -493,7 +468,12 @@ export function makeStore(
         glossaryPairs: config.glossaryPairs,
     });
 
-    return new TranslationStore(file, fingerprint);
+    // Seeds derived from existing target files (see `yfm translate seed`)
+    // are provider-agnostic and survive fingerprint changes by design.
+    const seeds = new SeedStore(seedFilePath(config.cacheDir, sourceLanguage, targetLanguage));
+    seeds.load();
+
+    return new TranslationStore(file, fingerprint, seeds);
 }
 
 /**

--- a/src/commands/translate/providers/ai/utils/cache.spec.ts
+++ b/src/commands/translate/providers/ai/utils/cache.spec.ts
@@ -3,9 +3,10 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, expect, it} from 'vitest';
 
-import {TranslationStore, cacheFingerprint} from './cache';
+import {SeedStore, TranslationStore, cacheFingerprint, seedFilePath} from './cache';
 
-const tmp = () => join(mkdtempSync(join(tmpdir(), 'yfm-translate-cache-')), 'store.json');
+const tmpDir = () => mkdtempSync(join(tmpdir(), 'yfm-translate-cache-'));
+const tmp = () => join(tmpDir(), 'store.json');
 
 describe('translate ai cache', () => {
     describe('TranslationStore', () => {
@@ -62,6 +63,126 @@ describe('translate ai cache', () => {
             store.flush();
 
             expect(JSON.parse(readFileSync(file, 'utf8')).translations).toBeTruthy();
+        });
+    });
+
+    describe('SeedStore', () => {
+        it('should persist seeded pairs between instances', () => {
+            const file = join(tmpDir(), 'seed.ru-en.json');
+
+            const first = new SeedStore(file);
+            first.load();
+            first.set('Привет', 'Hello');
+            first.flush();
+
+            const second = new SeedStore(file);
+            second.load();
+
+            expect(second.get('Привет')).toBe('Hello');
+            expect(second.get('Другое')).toBeUndefined();
+        });
+
+        it('should survive a corrupted seed file', () => {
+            const file = join(tmpDir(), 'seed.ru-en.json');
+            writeFileSync(file, 'not a json');
+
+            const store = new SeedStore(file);
+
+            expect(() => store.load()).not.toThrow();
+            expect(store.get('Привет')).toBeUndefined();
+        });
+
+        it('should rebuild the file from scratch on flush', () => {
+            const file = join(tmpDir(), 'seed.ru-en.json');
+
+            const first = new SeedStore(file);
+            first.load();
+            first.set('Привет', 'Hello');
+            first.set('Пока', 'Bye');
+            first.flush();
+
+            // A later seeding run derives the state anew and must fully
+            // replace stale entries, not merge with them.
+            const second = new SeedStore(file);
+            second.set('Привет', 'Hi');
+            second.flush();
+
+            const third = new SeedStore(file);
+            third.load();
+
+            expect(third.get('Привет')).toBe('Hi');
+            expect(third.get('Пока')).toBeUndefined();
+        });
+    });
+
+    describe('TranslationStore with seeds', () => {
+        it('should fall back to seeds for units missing in translations', () => {
+            const dir = tmpDir();
+            const seeds = new SeedStore(join(dir, 'seed.ru-en.json'));
+            seeds.set('Привет', 'Hello');
+            seeds.flush();
+            seeds.load();
+
+            const store = new TranslationStore(
+                join(dir, 'store.json'),
+                cacheFingerprint({}),
+                seeds,
+            );
+            store.load();
+
+            expect(store.get('Привет')).toBe('Hello');
+            expect(store.get('Другое')).toBeUndefined();
+        });
+
+        it('should prefer seeds over stored translations', () => {
+            // Seeds reflect the current state of target files (including
+            // manual edits), so they win over older LLM translations.
+            const dir = tmpDir();
+
+            const store = new TranslationStore(join(dir, 'store.json'), cacheFingerprint({}));
+            store.load();
+            store.set('Привет', 'Hello');
+            store.flush();
+
+            const seeds = new SeedStore(join(dir, 'seed.ru-en.json'));
+            seeds.set('Привет', 'Hi there');
+            seeds.flush();
+            seeds.load();
+
+            const second = new TranslationStore(
+                join(dir, 'store.json'),
+                cacheFingerprint({}),
+                seeds,
+            );
+            second.load();
+
+            expect(second.get('Привет')).toBe('Hi there');
+        });
+
+        it('should not write seeds into the translations file', () => {
+            const dir = tmpDir();
+            const seeds = new SeedStore(join(dir, 'seed.ru-en.json'));
+            seeds.set('Привет', 'Hello');
+            seeds.flush();
+            seeds.load();
+
+            const file = join(dir, 'store.json');
+            const store = new TranslationStore(file, cacheFingerprint({}), seeds);
+            store.load();
+            store.set('Пока', 'Bye');
+            store.flush();
+
+            const written = JSON.parse(readFileSync(file, 'utf8'));
+
+            expect(Object.keys(written.translations)).toHaveLength(1);
+        });
+    });
+
+    describe('seedFilePath', () => {
+        it('should build one seed file per language pair', () => {
+            expect(seedFilePath('/cache' as AbsolutePath, 'ru', 'en')).toBe(
+                join('/cache', 'seed.ru-en.json'),
+            );
         });
     });
 });

--- a/src/commands/translate/providers/ai/utils/cache.ts
+++ b/src/commands/translate/providers/ai/utils/cache.ts
@@ -1,6 +1,6 @@
 import {createHash} from 'node:crypto';
 import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs';
-import {dirname} from 'node:path';
+import {dirname, join} from 'node:path';
 
 const VERSION = 1;
 
@@ -23,23 +23,95 @@ export function cacheFingerprint(parts: unknown): string {
 }
 
 /**
+ * Path of the seed file for a language pair. Seeds are provider- and
+ * model-agnostic, so the name depends on the languages only.
+ */
+export function seedFilePath(cacheDir: string, source: string, target: string): string {
+    return join(cacheDir, `seed.${source}-${target}.json`);
+}
+
+type SeedFile = {
+    version: number;
+    translations: Record<string, string>;
+};
+
+/**
+ * Fingerprint-free translation memory derived from existing target files.
+ *
+ * Unlike TranslationStore, seeds represent the observable state of the
+ * repository, not an LLM output, so they survive prompt, glossary and
+ * model changes. Each seeding run derives the state anew, so flush()
+ * fully replaces the file.
+ */
+export class SeedStore {
+    private readonly file: string;
+
+    private translations: Record<string, string> = {};
+
+    constructor(file: string) {
+        this.file = file;
+    }
+
+    load() {
+        if (!existsSync(this.file)) {
+            return;
+        }
+
+        try {
+            const data = JSON.parse(readFileSync(this.file, 'utf8')) as SeedFile;
+            if (data.version === VERSION && data.translations) {
+                this.translations = data.translations;
+            }
+        } catch {
+            // A corrupted seed file is not fatal - start from scratch.
+        }
+    }
+
+    get(text: string): string | undefined {
+        return this.translations[hash(text)];
+    }
+
+    set(text: string, translation: string) {
+        this.translations[hash(text)] = translation;
+    }
+
+    flush() {
+        mkdirSync(dirname(this.file), {recursive: true});
+        writeFileSync(
+            this.file,
+            JSON.stringify({
+                version: VERSION,
+                translations: this.translations,
+            }),
+        );
+    }
+}
+
+/**
  * File-backed translation memory: unit text hash -> translation.
  *
  * The store is loaded once per run and flushed after each processed file,
  * so repeated runs only send new or changed units to the LLM.
+ *
+ * Optional seeds are consulted first: they reflect the current state of
+ * the target files (including manual edits), which outranks translations
+ * produced by earlier runs.
  */
 export class TranslationStore {
     private readonly file: string;
 
     private readonly fingerprint: string;
 
+    private readonly seeds?: SeedStore;
+
     private translations: Record<string, string> = {};
 
     private dirty = false;
 
-    constructor(file: string, fingerprint: string) {
+    constructor(file: string, fingerprint: string, seeds?: SeedStore) {
         this.file = file;
         this.fingerprint = fingerprint;
+        this.seeds = seeds;
     }
 
     load() {
@@ -62,7 +134,7 @@ export class TranslationStore {
     }
 
     get(text: string): string | undefined {
-        return this.translations[hash(text)];
+        return this.seeds?.get(text) ?? this.translations[hash(text)];
     }
 
     set(text: string, translation: string) {

--- a/src/commands/translate/providers/ai/utils/index.ts
+++ b/src/commands/translate/providers/ai/utils/index.ts
@@ -7,7 +7,8 @@ export {
     LLMResponseError,
     throwLLMError,
 } from './errors';
-export {TranslationStore, cacheFingerprint} from './cache';
+export {SeedStore, TranslationStore, cacheFingerprint, seedFilePath} from './cache';
+export {collectSeedPairs} from './seed';
 
 export class Defer<T = string> {
     resolve!: (text: T) => void;

--- a/src/commands/translate/providers/ai/utils/seed.spec.ts
+++ b/src/commands/translate/providers/ai/utils/seed.spec.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it} from 'vitest';
+
+import {collectSeedPairs} from './seed';
+
+const CYRILLIC = /\p{Script=Cyrillic}/u;
+
+const unit = (text: string) => `<source xml:space="preserve">${text}</source>`;
+
+describe('translate seed pairs', () => {
+    describe('collectSeedPairs', () => {
+        it('should pair units positionally when counts match', () => {
+            const result = collectSeedPairs(
+                [unit('Привет.'), unit('Пока.')],
+                [unit('Hello.'), unit('Bye.')],
+                CYRILLIC,
+            );
+
+            expect(result.status).toBe('aligned');
+            if (result.status === 'aligned') {
+                expect(result.pairs).toEqual([
+                    [unit('Привет.'), unit('Hello.')],
+                    [unit('Пока.'), unit('Bye.')],
+                ]);
+                expect(result.skipped).toBe(0);
+            }
+        });
+
+        it('should report a mismatch when unit counts differ', () => {
+            const result = collectSeedPairs(
+                [unit('Привет.'), unit('Пока.')],
+                [unit('Hello.')],
+                CYRILLIC,
+            );
+
+            expect(result).toEqual({status: 'mismatch', sourceCount: 2, targetCount: 1});
+        });
+
+        it('should skip identity pairs that still look untranslated', () => {
+            // The target file kept the source text as is - seeding it would
+            // freeze the untranslated leftover forever. Skipping lets the
+            // next translate run send it to the LLM.
+            const result = collectSeedPairs(
+                [unit('Привет.'), unit('yfm build')],
+                [unit('Привет.'), unit('yfm build')],
+                CYRILLIC,
+            );
+
+            expect(result.status).toBe('aligned');
+            if (result.status === 'aligned') {
+                // Latin-only identity is a legitimately untranslatable unit.
+                expect(result.pairs).toEqual([[unit('yfm build'), unit('yfm build')]]);
+                expect(result.skipped).toBe(1);
+            }
+        });
+
+        it('should seed identity pairs when no marker is available', () => {
+            const result = collectSeedPairs([unit('Привет.')], [unit('Привет.')], null);
+
+            expect(result.status).toBe('aligned');
+            if (result.status === 'aligned') {
+                expect(result.pairs).toEqual([[unit('Привет.'), unit('Привет.')]]);
+                expect(result.skipped).toBe(0);
+            }
+        });
+    });
+});

--- a/src/commands/translate/providers/ai/utils/seed.ts
+++ b/src/commands/translate/providers/ai/utils/seed.ts
@@ -1,0 +1,46 @@
+export type SeedPairsResult =
+    | {status: 'aligned'; pairs: [string, string][]; skipped: number}
+    | {status: 'mismatch'; sourceCount: number; targetCount: number};
+
+/**
+ * Pairs source units with target units positionally.
+ *
+ * Positional pairing is only safe when both files split into the same
+ * number of units; otherwise a single merged or split sentence shifts
+ * the rest of the file and every later pair is wrong - such files are
+ * reported as a mismatch and must not be seeded.
+ *
+ * Identity pairs that still contain source-script characters are
+ * untranslated leftovers: seeding them would freeze the source text as
+ * a "translation", so they are skipped and left for the LLM.
+ */
+export function collectSeedPairs(
+    sourceUnits: string[],
+    targetUnits: string[],
+    marker: RegExp | null,
+): SeedPairsResult {
+    if (sourceUnits.length !== targetUnits.length) {
+        return {
+            status: 'mismatch',
+            sourceCount: sourceUnits.length,
+            targetCount: targetUnits.length,
+        };
+    }
+
+    const pairs: [string, string][] = [];
+    let skipped = 0;
+
+    for (let index = 0; index < sourceUnits.length; index++) {
+        const source = sourceUnits[index];
+        const target = targetUnits[index];
+
+        if (source === target && marker?.test(source)) {
+            skipped++;
+            continue;
+        }
+
+        pairs.push([source, target]);
+    }
+
+    return {status: 'aligned', pairs, skipped};
+}

--- a/src/commands/translate/utils/index.ts
+++ b/src/commands/translate/utils/index.ts
@@ -1,6 +1,7 @@
 export type {Locale} from './config';
 export {resolveSchemas, FileLoader, copyAssets, languageRepath} from './fs';
 export {extract, compose} from './translate';
+export {loadTranslationUnits} from './units';
 export {resolveSource, resolveTargets, resolveFiles, resolveVars} from './config';
 export {
     TranslateError,

--- a/src/commands/translate/utils/units.spec.ts
+++ b/src/commands/translate/utils/units.spec.ts
@@ -1,0 +1,76 @@
+import {mkdirSync, mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {describe, expect, it} from 'vitest';
+
+import {loadTranslationUnits} from './units';
+
+function file(content: string, name = 'article.md') {
+    const dir = mkdtempSync(join(tmpdir(), 'yfm-translate-units-'));
+    const path = join(dir, name);
+    mkdirSync(join(dir, 'ru'), {recursive: true});
+    writeFileSync(path, content);
+    return path as AbsolutePath;
+}
+
+describe('translate units loader', () => {
+    describe('loadTranslationUnits', () => {
+        it('should extract translation units from a markdown file', async () => {
+            const inputPath = file('# Заголовок\n\nПервое предложение. Второе предложение.\n');
+
+            const {units} = await loadTranslationUnits({
+                inputPath,
+                path: 'ru/article.md',
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+            });
+
+            expect(units.length).toBe(3);
+            expect(units[0]).toContain('Заголовок');
+            expect(units[1]).toContain('Первое предложение.');
+            expect(units[2]).toContain('Второе предложение.');
+        });
+
+        it('should apply liquid conditions when vars are provided', async () => {
+            const inputPath = file(
+                '{% if audience == "internal" %}\nВнутреннее.\n{% endif %}\n\nОбщее.\n',
+            );
+
+            const withVars = await loadTranslationUnits({
+                inputPath,
+                path: 'ru/article.md',
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {audience: 'external'},
+            });
+            const withoutVars = await loadTranslationUnits({
+                inputPath,
+                path: 'ru/article.md',
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+            });
+
+            // The failed condition drops the internal block entirely.
+            expect(withVars.units.join('\n')).not.toContain('Внутреннее');
+            expect(withVars.units.join('\n')).toContain('Общее');
+            // Without vars liquid is not applied and the text stays.
+            expect(withoutVars.units.join('\n')).toContain('Внутреннее');
+        });
+
+        it('should return no units for an empty file', async () => {
+            const inputPath = file('');
+
+            const {units} = await loadTranslationUnits({
+                inputPath,
+                path: 'ru/article.md',
+                sourceLanguage: 'ru',
+                targetLanguage: 'en',
+                vars: {},
+            });
+
+            expect(units).toEqual([]);
+        });
+    });
+});

--- a/src/commands/translate/utils/units.spec.ts
+++ b/src/commands/translate/utils/units.spec.ts
@@ -26,7 +26,7 @@ describe('translate units loader', () => {
                 vars: {},
             });
 
-            expect(units.length).toBe(3);
+            expect(units).toHaveLength(3);
             expect(units[0]).toContain('Заголовок');
             expect(units[1]).toContain('Первое предложение.');
             expect(units[2]).toContain('Второе предложение.');

--- a/src/commands/translate/utils/units.ts
+++ b/src/commands/translate/utils/units.ts
@@ -1,0 +1,66 @@
+import type {ExtractOptions} from '@diplodoc/translation';
+
+import liquid from '@diplodoc/transform/lib/liquid';
+
+import {FileLoader, resolveSchemas} from './fs';
+import {extract} from './translate';
+
+export type LoadTranslationUnitsParams = {
+    /** Absolute path of the file to read. */
+    inputPath: AbsolutePath;
+    /** Input-relative path, used for schema resolution. */
+    path: string;
+    sourceLanguage: string;
+    targetLanguage: string;
+    vars: Record<string, unknown>;
+};
+
+export type LoadedTranslationUnits = {
+    content: FileLoader<string | object>;
+    units: string[];
+    skeleton?: string;
+    schemas?: ExtractOptions['schemas'];
+    ajvOptions?: ExtractOptions['ajvOptions'];
+};
+
+/**
+ * Loads a file and extracts translation units exactly the way the AI
+ * translate run does: same liquid handling, same extract options.
+ *
+ * Any consumer that needs cache-key parity with translation (seeding,
+ * cache inspection) must go through this helper - a single divergence
+ * in preprocessing changes unit texts and silently misses the cache.
+ */
+export async function loadTranslationUnits(
+    params: LoadTranslationUnitsParams,
+): Promise<LoadedTranslationUnits> {
+    const {inputPath, path, sourceLanguage, targetLanguage, vars} = params;
+
+    const content = new FileLoader(inputPath);
+    await content.load();
+
+    if (Object.keys(vars).length && content.isString) {
+        content.set(
+            liquid(content.data as string, vars, inputPath, {
+                conditions: 'strict',
+                substitutions: false,
+                cycles: false,
+            }),
+        );
+    }
+
+    if (!content.data) {
+        return {content, units: []};
+    }
+
+    const {schemas, ajvOptions} = await resolveSchemas({content: content.data, path});
+    const {units, skeleton} = extract(content.data, {
+        compact: true,
+        source: {language: sourceLanguage, locale: 'RU'},
+        target: {language: targetLanguage, locale: 'US'},
+        schemas,
+        ajvOptions,
+    });
+
+    return {content, units, skeleton, schemas, ajvOptions};
+}


### PR DESCRIPTION
## Motivation

When a project already has translated files, a translate run with an empty cache retranslates everything and overwrites the existing targets, losing manual edits along the way. This PR lets the cache be derived from the translations that already exist in the repository, so incremental runs only pay for new or changed units.

DOCSTOOLS-6489

## Changes

- New `yfm translate seed` command: for every source file with an existing translation, extracts units from both sides (exactly the way the translate run does), aligns them positionally and writes the pairs into `seed.<source>-<target>.json` in `--cache-dir`.
- `SeedStore`: fingerprint-free store consulted by `TranslationStore` before its own entries. Seeds represent the observable state of target files (including manual edits), so they outrank older LLM translations and survive prompt/glossary/model changes.
- Alignment safety: files whose unit counts diverge (a merged or split sentence shifts positional pairing) are reported and skipped - they fall back to full retranslation instead of getting wrong pairs. Identity pairs that still contain source-script characters are untranslated leftovers and are not seeded, so the next run retries them.
- `loadTranslationUnits` helper shared between the translate processor and seeding guarantees cache-key parity (same liquid handling, same extract options).

## Numbers

Measured on diplodoc-platform/docs (98 ru/en article pairs, machine-translated): 98% of files align positionally, covering 97.7% of units. Live smoke on the current repo HEAD: `seed` filled 5331 units from 103 files (3 mismatches reported), a following `translate --dry-run` served 4634 units from the cache and left 65 LLM requests for the actually changed content.