### PR TITLE
fix(llms): exclude noIndex pages from llms.txt and llms-full.txt DOCSTOOLS-6559

### DIFF
--- a/src/commands/build/features/llms/index.spec.ts
+++ b/src/commands/build/features/llms/index.spec.ts
@@ -102,6 +102,7 @@ type TestableLlms = {
         onlyMd: boolean,
     ): boolean;
     collectEntries(toc: Toc, tocDir: string): unknown[];
+    excludeNoIndex(run: Run, entries: unknown[]): Promise<unknown[]>;
     renderIndex(run: Run, title: string, entries: unknown[], tocDir: string): Promise<string>;
     renderFull(run: Run, title: string, entries: unknown[]): Promise<string>;
 };
@@ -111,6 +112,60 @@ describe('LLMs Plugin Architecture', () => {
 
     beforeEach(() => {
         llmsInstance = new Llms() as unknown as TestableLlms;
+    });
+
+    // `noIndex` is the front-matter twin of the toc-level `hidden` flag: both mean
+    // "keep this page out of indexes", and an LLM corpus is an index. Filtering
+    // belongs to the build, because the flag is static and identical for every
+    // reader — consumers must be able to trust the generated artifacts as-is.
+    describe('excludeNoIndex', () => {
+        const entry = (path: string) => ({
+            href: normalizedPath(path),
+            path: normalizedPath(path),
+            name: path,
+            parentName: '',
+        });
+
+        const runWithMeta = (metaByPath: Record<string, unknown>) =>
+            ({
+                meta: {
+                    dump: vi.fn(async (path: string) => metaByPath[path] ?? {}),
+                },
+            }) as unknown as Run;
+
+        it('drops pages marked noIndex', async () => {
+            const entries = [entry('public.md'), entry('secret.md')];
+            const run = runWithMeta({'secret.md': {noIndex: true}});
+
+            await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual([
+                entry('public.md'),
+            ]);
+        });
+
+        it('keeps pages without the flag and with noIndex: false', async () => {
+            const entries = [entry('a.md'), entry('b.md')];
+            const run = runWithMeta({'b.md': {noIndex: false}});
+
+            await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual(entries);
+        });
+
+        // Only a real `true` hides a page: a truthy string from malformed front
+        // matter must not silently drop content from the corpus.
+        it('treats a non-boolean noIndex value as not set', async () => {
+            const entries = [entry('a.md')];
+            const run = runWithMeta({'a.md': {noIndex: 'yes'}});
+
+            await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual(entries);
+        });
+
+        it('keeps a page whose meta cannot be read', async () => {
+            const entries = [entry('broken.md')];
+            const run = {
+                meta: {dump: vi.fn().mockRejectedValue(new Error('unreadable'))},
+            } as unknown as Run;
+
+            await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual(entries);
+        });
     });
 
     describe('resolveLlmsEnabled logic', () => {

--- a/src/commands/build/features/llms/index.ts
+++ b/src/commands/build/features/llms/index.ts
@@ -63,8 +63,9 @@ type LlmsTocItem = {
  * Runs in `AfterAnyRun`, so it works for both `md` and `html` builds. By that
  * point the toc is already resolved and filtered for the current build
  * (vars/conditions and `removeEmptyTocItems`). Hidden items are filtered here
- * independently of `removeHiddenTocItems`, so hidden pages don't leak into
- * either artifact while remaining available to the regular build. Walking
+ * independently of `removeHiddenTocItems`, and pages marked `noIndex` in their
+ * front matter are dropped as well, so neither leaks into either artifact while
+ * both remain available to the regular build. Walking
  * `run.toc.tocs` mirrors `SinglePage`.
  *
  * `llms-full.txt` is assembled with {@link MarkdownCollector} — the same engine
@@ -131,7 +132,7 @@ export class Llms {
 
     private async generate(run: Run, toc: Toc) {
         const tocDir = dirname(toc.path);
-        const entries = this.collectEntries(toc, tocDir);
+        const entries = await this.excludeNoIndex(run, this.collectEntries(toc, tocDir));
 
         if (!entries.length) {
             return;
@@ -144,6 +145,39 @@ export class Llms {
 
         await run.write(join(run.output, tocDir, LLMS_INDEX_FILENAME), index, true);
         await run.write(join(run.output, tocDir, LLMS_FULL_FILENAME), full, true);
+    }
+
+    /**
+     * Drops pages marked `noIndex` in their front matter.
+     *
+     * `noIndex` means "keep this page out of indexes". An LLM corpus is exactly
+     * such an index, so these pages must not reach `llms.txt` or `llms-full.txt`
+     * — the same reasoning as for `hidden` in {@link collectEntries}; only the
+     * source of the flag differs: `hidden` is a toc property, `noIndex` is page
+     * meta.
+     *
+     * This lives here rather than in `collectEntries` because meta is read
+     * asynchronously. Filtering once for both artifacts also guarantees the index
+     * and the corpus stay consistent with each other.
+     *
+     * A page whose meta cannot be read is kept: an unreadable file must not
+     * silently vanish from the corpus, and the renderers already report such
+     * failures.
+     */
+    private async excludeNoIndex(run: Run, entries: LlmsEntry[]): Promise<LlmsEntry[]> {
+        const noIndexFlags = await Promise.all(
+            entries.map(async (entry) => {
+                try {
+                    const meta = await run.meta.dump(entry.path);
+
+                    return meta?.noIndex === true;
+                } catch {
+                    return false;
+                }
+            }),
+        );
+
+        return entries.filter((_entry, index) => !noIndexFlags[index]);
     }
 
     private collectEntries(toc: LlmsTocItem, tocDir: string): LlmsEntry[] {

--- a/tests/e2e/__snapshots__/load-custom-resources.spec.ts.snap
+++ b/tests/e2e/__snapshots__/load-custom-resources.spec.ts.snap
@@ -336,7 +336,6 @@ exports[`Allow load custom resources > md2md with custom resources 4`] = `
 
 ## Documentation
 
-- [Documentation](index.yaml)
 - [Documentation](page.md): Some test description
 - [Config](project/config.md)
 

--- a/tests/e2e/__snapshots__/metadata.spec.ts.snap
+++ b/tests/e2e/__snapshots__/metadata.spec.ts.snap
@@ -173,7 +173,6 @@ exports[`Allow load custom resources > md2md with metadata 3`] = `
 
 ## Documentation
 
-- [Documentation](index.yaml)
 - [Documentation](page.md): Some test description
 - [Config](project/config.md)
 


### PR DESCRIPTION
`noIndex` means "keep this page out of indexes", and an LLM corpus is exactly such an index. Until now only the toc-level `hidden` flag was honoured (DOCSTOOLS-6195), so a page marked `noIndex: true` in its front matter still landed in both artifacts.

Both flags are static build-time metadata, identical for every reader, so filtering belongs here rather than in the viewer: consumers must be able to trust the generated files as-is, and duplicating the rule downstream would let the two copies drift apart.

Implementation notes:
- filtering runs in `generate`, not `collectEntries`, because meta is read asynchronously; doing it once keeps the index and the corpus consistent;
- only a real boolean `true` hides a page, so a malformed front-matter value cannot silently drop content;
- a page whose meta cannot be read is kept — an unreadable file must not quietly vanish from the corpus.

Verified: vitest 1802 passed (4 new, checked to fail without the fix), tsc --noEmit clean.