### PR TITLE
fix(llms): check noIndex in docs-viewer namespace

### DIFF
--- a/src/commands/build/features/llms/index.spec.ts
+++ b/src/commands/build/features/llms/index.spec.ts
@@ -142,6 +142,22 @@ describe('LLMs Plugin Architecture', () => {
             ]);
         });
 
+        // The test docs declare noIndex under the `docs-viewer` namespace:
+        //   ---
+        //   docs-viewer:
+        //     noIndex: true
+        //   ---
+        // The meta dump returns it as `meta['docs-viewer'].noIndex`, not
+        // `meta.noIndex`. excludeNoIndex must check both locations.
+        it('drops pages with noIndex in the docs-viewer namespace', async () => {
+            const entries = [entry('public.md'), entry('secret.md')];
+            const run = runWithMeta({'secret.md': {'docs-viewer': {noIndex: true}}});
+
+            await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual([
+                entry('public.md'),
+            ]);
+        });
+
         it('keeps pages without the flag and with noIndex: false', async () => {
             const entries = [entry('a.md'), entry('b.md')];
             const run = runWithMeta({'b.md': {noIndex: false}});

--- a/src/commands/build/features/llms/index.ts
+++ b/src/commands/build/features/llms/index.ts
@@ -170,7 +170,13 @@ export class Llms {
                 try {
                     const meta = await run.meta.dump(entry.path);
 
-                    return meta?.noIndex === true;
+                    // `noIndex` can live at the meta root (standard YFM frontmatter)
+                    // or under the `docs-viewer` namespace (viewer-specific config).
+                    // Check both: the test docs use `docs-viewer: { noIndex: true }`.
+                    return (
+                        meta?.noIndex === true ||
+                        (meta?.['docs-viewer'] as {noIndex?: boolean})?.noIndex === true
+                    );
                 } catch {
                     return false;
                 }


### PR DESCRIPTION
The test docs declare noIndex under the docs-viewer namespace: --- docs-viewer:
    noIndex: true
  --- The meta dump returns it as meta['docs-viewer'].noIndex, not meta.noIndex. excludeNoIndex must check both locations.