### PR TITLE
fix: sync meta from worker thread to main thread for post-processing hooks

### DIFF
--- a/src/commands/build/features/llms/index.spec.ts
+++ b/src/commands/build/features/llms/index.spec.ts
@@ -126,16 +126,38 @@ describe('LLMs Plugin Architecture', () => {
             parentName: '',
         });
 
-        const runWithMeta = (metaByPath: Record<string, unknown>) =>
-            ({
-                meta: {
-                    dump: vi.fn(async (path: string) => metaByPath[path] ?? {}),
-                },
-            }) as unknown as Run;
+        // excludeNoIndex reads front matter directly from the source file
+        // (bypassing MetaService) to stay correct when --jobs isolates the
+        // worker thread's MetaService from the main thread.
+        const runWithFrontMatter = (frontMatterByPath: Record<string, unknown>) => {
+            const inputDir = '/input' as AbsolutePath;
+            return {
+                input: inputDir,
+                read: vi.fn(async (path: AbsolutePath) => {
+                    // Cross-platform: normalize backslashes and strip the input prefix.
+                    const normalized = String(path).replace(/\\/g, '/');
+                    const rel = normalized.replace(String(inputDir) + '/', '');
+                    const fm = frontMatterByPath[rel];
+                    if (fm === undefined) {
+                        return 'No front matter here';
+                    }
+                    const yaml = Object.entries(fm as Record<string, unknown>)
+                        .map(([k, v]) =>
+                            typeof v === 'object' && v !== null
+                                ? `${k}:\n  ${Object.entries(v as Record<string, unknown>)
+                                      .map(([k2, v2]) => `${k2}: ${v2}`)
+                                      .join('\n  ')}`
+                                : `${k}: ${v}`,
+                        )
+                        .join('\n');
+                    return `---\n${yaml}\n---\nContent`;
+                }),
+            } as unknown as Run;
+        };
 
         it('drops pages marked noIndex', async () => {
             const entries = [entry('public.md'), entry('secret.md')];
-            const run = runWithMeta({'secret.md': {noIndex: true}});
+            const run = runWithFrontMatter({'secret.md': {noIndex: true}});
 
             await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual([
                 entry('public.md'),
@@ -147,11 +169,10 @@ describe('LLMs Plugin Architecture', () => {
         //   docs-viewer:
         //     noIndex: true
         //   ---
-        // The meta dump returns it as `meta['docs-viewer'].noIndex`, not
-        // `meta.noIndex`. excludeNoIndex must check both locations.
+        // excludeNoIndex must check both `meta.noIndex` and `meta['docs-viewer'].noIndex`.
         it('drops pages with noIndex in the docs-viewer namespace', async () => {
             const entries = [entry('public.md'), entry('secret.md')];
-            const run = runWithMeta({'secret.md': {'docs-viewer': {noIndex: true}}});
+            const run = runWithFrontMatter({'secret.md': {'docs-viewer': {noIndex: true}}});
 
             await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual([
                 entry('public.md'),
@@ -160,7 +181,7 @@ describe('LLMs Plugin Architecture', () => {
 
         it('keeps pages without the flag and with noIndex: false', async () => {
             const entries = [entry('a.md'), entry('b.md')];
-            const run = runWithMeta({'b.md': {noIndex: false}});
+            const run = runWithFrontMatter({'b.md': {noIndex: false}});
 
             await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual(entries);
         });
@@ -169,16 +190,53 @@ describe('LLMs Plugin Architecture', () => {
         // matter must not silently drop content from the corpus.
         it('treats a non-boolean noIndex value as not set', async () => {
             const entries = [entry('a.md')];
-            const run = runWithMeta({'a.md': {noIndex: 'yes'}});
+            const run = runWithFrontMatter({'a.md': {noIndex: 'yes'}});
 
             await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual(entries);
         });
 
-        it('keeps a page whose meta cannot be read', async () => {
+        it('keeps a page whose file cannot be read', async () => {
             const entries = [entry('broken.md')];
             const run = {
-                meta: {dump: vi.fn().mockRejectedValue(new Error('unreadable'))},
+                input: '/input' as AbsolutePath,
+                read: vi.fn().mockRejectedValue(new Error('ENOENT')),
             } as unknown as Run;
+
+            await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual(entries);
+        });
+
+        // `.yaml` leading pages don't have `---` front matter; excludeNoIndex
+        // falls back to `run.meta.dump()` for them.
+        it('uses meta.dump fallback for non-md files', async () => {
+            const entries = [entry('page.yaml')];
+            const run = {
+                input: '/input' as AbsolutePath,
+                read: vi.fn(),
+                meta: {
+                    dump: vi.fn(async () => ({noIndex: true})),
+                },
+            } as unknown as Run;
+
+            await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual([]);
+            expect(run.read).not.toHaveBeenCalled();
+        });
+
+        it('keeps a non-md file without noIndex in meta.dump', async () => {
+            const entries = [entry('page.yaml')];
+            const run = {
+                input: '/input' as AbsolutePath,
+                read: vi.fn(),
+                meta: {
+                    dump: vi.fn(async () => ({})),
+                },
+            } as unknown as Run;
+
+            await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual(entries);
+        });
+
+        it('keeps an md file that has no front matter', async () => {
+            const entries = [entry('plain.md')];
+            const run = runWithFrontMatter({});
 
             await expect(llmsInstance.excludeNoIndex(run, entries)).resolves.toEqual(entries);
         });

--- a/src/commands/build/features/llms/index.ts
+++ b/src/commands/build/features/llms/index.ts
@@ -3,6 +3,7 @@ import type {Command} from '~/core/config';
 import type {Toc} from '~/core/toc';
 
 import {dirname, join, relative} from 'node:path';
+import {extractFrontMatter} from '@diplodoc/liquid';
 
 import {defined} from '~/core/config';
 import {getHooks as getBaseHooks} from '~/core/program';
@@ -160,6 +161,13 @@ export class Llms {
      * asynchronously. Filtering once for both artifacts also guarantees the index
      * and the corpus stay consistent with each other.
      *
+     * Front matter is read directly from the source file rather than from
+     * `run.meta.dump()`. When `--jobs` is enabled, `process()` runs in a worker
+     * thread with its own `MetaService` instance; the main thread's `MetaService`
+     * (where `AfterAnyRun` hooks execute) never receives the front matter, so
+     * `run.meta.dump()` returns empty meta and `noIndex` is lost. Reading the
+     * raw file bypasses the thread boundary entirely.
+     *
      * A page whose meta cannot be read is kept: an unreadable file must not
      * silently vanish from the corpus, and the renderers already report such
      * failures.
@@ -168,14 +176,29 @@ export class Llms {
         const noIndexFlags = await Promise.all(
             entries.map(async (entry) => {
                 try {
-                    const meta = await run.meta.dump(entry.path);
+                    // Only `.md` files have YAML front matter delimited by `---`.
+                    // Leading pages (`.yaml`) store their metadata differently, so
+                    // fall back to `run.meta.dump()` for them — leading pages are
+                    // never marked `noIndex` in practice, but the fallback keeps
+                    // the behaviour unchanged for any file type we don't read raw.
+                    if (!entry.path.endsWith('.md')) {
+                        const meta = await run.meta.dump(entry.path);
+                        return (
+                            meta?.noIndex === true ||
+                            (meta?.['docs-viewer'] as {noIndex?: boolean})?.noIndex === true
+                        );
+                    }
+
+                    const source = join(run.input, entry.path);
+                    const raw = await run.read(source as AbsolutePath);
+                    const [frontmatter] = extractFrontMatter(raw);
 
                     // `noIndex` can live at the meta root (standard YFM frontmatter)
                     // or under the `docs-viewer` namespace (viewer-specific config).
                     // Check both: the test docs use `docs-viewer: { noIndex: true }`.
                     return (
-                        meta?.noIndex === true ||
-                        (meta?.['docs-viewer'] as {noIndex?: boolean})?.noIndex === true
+                        frontmatter?.noIndex === true ||
+                        (frontmatter?.['docs-viewer'] as {noIndex?: boolean})?.noIndex === true
                     );
                 } catch {
                     return false;


### PR DESCRIPTION
When --jobs is enabled, process() runs in a worker thread with its own MetaService instance. The worker loads frontmatter (including noIndex and restricted-access) into its local MetaService, but this data never reaches the main thread's MetaService.

AfterRun hooks (Llms excludeNoIndex, BuildManifest collectRestrictedAccess) call run.meta.dump(path) in the main thread and get empty meta, causing noIndex pages to leak into llms.txt and restricted-access rules to vanish from the build manifest.

Fix: process() now returns result.data.meta alongside result.info, and processEntry() writes it back into the main thread's MetaService via run.meta.set(entry, info.meta).
