### PR TITLE
chore(deps): bump @diplodoc/translation to 1.7.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@diplodoc/color-extension": "^1.0.0",
         "@diplodoc/liquid": "^1.5.3",
         "@diplodoc/transform": "^4.77.12",
-        "@diplodoc/translation": "^1.7.30",
+        "@diplodoc/translation": "^1.7.31",
         "@diplodoc/utils": "^2.3.6",
         "@gravity-ui/uikit-themer": "^1.7.0",
         "@inquirer/prompts": "^8.3.2",
@@ -2087,9 +2087,9 @@
       }
     },
     "node_modules/@diplodoc/translation": {
-      "version": "1.7.30",
-      "resolved": "https://registry.npmjs.org/@diplodoc/translation/-/translation-1.7.30.tgz",
-      "integrity": "sha512-PovcE5ZA9KvSJLxgCo2JUQ2iQ1diucpDb/cqorIoi3sx+We+GyOHuOd3bCT+3qLOT5i+3kO3tJ5KlQVWToTERw==",
+      "version": "1.7.31",
+      "resolved": "https://registry.npmjs.org/@diplodoc/translation/-/translation-1.7.31.tgz",
+      "integrity": "sha512-4ADDOAqTPJq8USspJU/9grnLN4gLETqc5Gk0pOtNjMfKhHs2ta7HhLtrLMWr3/qZvPwpkLBoT69AmF3SkiYQdg==",
       "license": "MIT",
       "dependencies": {
         "@cospired/i18n-iso-languages": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@diplodoc/color-extension": "^1.0.0",
     "@diplodoc/liquid": "^1.5.3",
     "@diplodoc/transform": "^4.77.12",
-    "@diplodoc/translation": "^1.7.30",
+    "@diplodoc/translation": "^1.7.31",
     "@diplodoc/utils": "^2.3.6",
     "@gravity-ui/uikit-themer": "^1.7.0",
     "@inquirer/prompts": "^8.3.2",

--- a/tests/e2e/__snapshots__/translation.spec.ts.snap
+++ b/tests/e2e/__snapshots__/translation.spec.ts.snap
@@ -2821,7 +2821,7 @@ exports[`Translate command > test no-translate directive 6`] = `
         <source xml:space="preserve">Simple get operation. тест новой верстки 3</source>
       </trans-unit>
       <trans-unit id="3">
-        <source xml:space="preserve">Defines a simple get <x ctype="no_translate_inline" equiv-text=":no-translate[skip this]" id="x-15"/> operation with no inputs and a complex</source>
+        <source xml:space="preserve">Defines a simple get <x ctype="no_translate_inline" equiv-text=":no-translate[skip this]" id="x-1"/> operation with no inputs and a complex</source>
       </trans-unit>
       <trans-unit id="4">
         <source xml:space="preserve">200!!!!</source>


### PR DESCRIPTION
Brings the placeholder-id reset fix (diplodoc-platform/translation#278): `extract()` now restarts `g-N`/`x-N` id sequences per document, so translation cache and seed keys are stable across runs and file sets. Without it, units containing markup missed the seed/cache whenever the process had extracted a different set of files before (measured: 10 of 45 units of an aligned file went to the LLM instead of being reused).

Lock updated surgically (only the @diplodoc/translation entry) to avoid the platform-specific optional-deps churn a full lock regeneration produces.