### PR TITLE
feat(translate): add --report flag with a machine-readable run report

### DIFF
--- a/docs/translate-run-report.md
+++ b/docs/translate-run-report.md
@@ -1,0 +1,174 @@
+# Translate run report
+
+`yfm translate --report <path>` writes a machine-readable JSON report of the
+translation run: timings, volume, cache and fallback usage, judge scores and
+errors. The report is meant for automation around translation (CI pipelines,
+usage analytics, dashboards).
+
+The flag is disabled by default and translation behavior does not depend on
+it. A short one-line run summary is always logged at the end of the run,
+with or without the flag:
+
+```
+INFO PROCESSED run success in 12.4s; files: 12 translated, 0 failed; units: 340 (154 cached, 45.3% hit rate); chars: 15200 in / 16900 out; tokens: 5200 in / 4800 out; requests: 18 (2 fallback, 3 retries); errors: 0
+```
+
+## Usage
+
+```sh
+yfm translate -i ./docs -o ./translated \
+    --provider openai --source ru --target en \
+    --report ./translate-report.json
+```
+
+The CLI path is resolved from the current working directory. The option can
+also be set in the `.yfm` config (`translate.report`), then the path is
+resolved from the config directory.
+
+## Schema versioning
+
+The report shape is a public contract. The `schemaVersion` field is bumped on
+any breaking change, so consumers must check it and reject versions they do
+not understand instead of silently misreading the data.
+
+The TypeScript types of the report are exported from the translate command
+module: `TranslateRunReport`, `TranslateReportCounters`,
+`TranslateReportTarget`, `TranslateReportJudge`, `TranslateReportError` and
+the `TRANSLATE_REPORT_SCHEMA_VERSION` constant.
+
+## Report structure
+
+Top-level fields:
+
+| Field             | Type     | Description                                                                                   |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `schemaVersion`   | number   | Report schema version, currently `1`.                                                         |
+| `startedAt`       | string   | ISO 8601 start time of the CLI process.                                                       |
+| `finishedAt`      | string   | ISO 8601 finish time.                                                                         |
+| `durationMs`      | number   | Run duration in milliseconds.                                                                 |
+| `status`          | string   | `success`, `partial` (completed with recorded errors) or `failed` (aborted on a fatal error). |
+| `provider`        | string   | Translation provider name (`openai`, `anthropic`, `yandexgpt`, `openrouter`, `yandex`).       |
+| `model`           | string?  | Model identifier (LLM providers only).                                                        |
+| `fallbackModel`   | string?  | The `--fallback-model` value when configured.                                                 |
+| `fallbackUsed`    | boolean  | True when at least one request was served by the fallback model.                              |
+| `dryRun`          | boolean  | True for `--dry-run`; volume and token numbers are estimates then.                            |
+| `sourceLanguage`  | string   | Source language.                                                                              |
+| `targetLanguages` | string[] | Target languages of the run.                                                                  |
+| `files`           | object   | `selected` - files picked for translation, `skipped` - files filtered out before translation. |
+| `totals`          | counters | Counters aggregated across all targets (see below).                                           |
+| `targets`         | target[] | Per-target-language counters, plus `judge` stats when `--judge` is enabled.                   |
+| `errors`          | error[]  | Every recorded error: `target?`, `path?`, stable `code`, `message`.                           |
+
+Counters (`totals` and each entry of `targets`):
+
+| Field                         | Type           | Description                                                                                                                          |
+| ----------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `files.translated`            | number         | Files processed successfully.                                                                                                        |
+| `files.failed`                | number         | Files that failed.                                                                                                                   |
+| `files.retried`               | number         | Files re-queued for the final sweep after transient errors.                                                                          |
+| `units.total`                 | number         | Translation units (segments) seen.                                                                                                   |
+| `units.translated`            | number         | Units translated by the provider during this run.                                                                                    |
+| `units.fromCache`             | number         | Units served from the persistent cache (including seeds).                                                                            |
+| `units.untranslated`          | number         | Units the model returned untranslated.                                                                                               |
+| `units.oversized`             | number         | Units skipped as too big for a single request.                                                                                       |
+| `chars.source`                | number         | Source characters across all seen units.                                                                                             |
+| `chars.translated`            | number         | Characters of translations produced during this run.                                                                                 |
+| `chars.request`               | number         | Characters actually sent in requests.                                                                                                |
+| `tokens`                      | object or null | `input`/`output` token usage as reported by the provider; `null` when the provider does not report usage. Estimated in dry-run mode. |
+| `requests.total`              | number         | Translation requests sent.                                                                                                           |
+| `requests.fallback`           | number         | Requests served by the fallback model.                                                                                               |
+| `requests.retries`            | number         | Extra request attempts after retryable errors.                                                                                       |
+| `cache.enabled`               | boolean        | Whether the persistent cache (`--cache-dir`) was active.                                                                             |
+| `cache.hits` / `cache.misses` | number         | Cache lookups by outcome.                                                                                                            |
+| `cache.hitRate`               | number or null | `hits / (hits + misses)`, `null` when the cache is disabled or was not consulted.                                                    |
+
+Judge stats (`targets[].judge`, present when `--judge` is enabled):
+
+| Field            | Type   | Description                                                   |
+| ---------------- | ------ | ------------------------------------------------------------- |
+| `model`          | string | Judge model.                                                  |
+| `threshold`      | number | `--judge-threshold` value.                                    |
+| `scored`         | number | Scored source/translation pairs.                              |
+| `averageScore`   | number | Average score, 0-100.                                         |
+| `belowThreshold` | number | Pairs scored below the threshold.                             |
+| `unscored`       | number | Pairs the judge failed to score.                              |
+| `distribution`   | object | Score histogram with stable keys `0-9` ... `90-99` and `100`. |
+
+Provider coverage: LLM providers (`openai`, `anthropic`, `yandexgpt`,
+`openrouter`) fill all counters. The `yandex` (Yandex Translate) provider has
+no token usage, persistent cache or judge, so `tokens` is `null`,
+`cache.enabled` is `false` and `judge` is absent.
+
+## Example
+
+```json
+{
+  "schemaVersion": 1,
+  "startedAt": "2026-08-25T10:00:00.000Z",
+  "finishedAt": "2026-08-25T10:00:12.400Z",
+  "durationMs": 12400,
+  "status": "success",
+  "provider": "openai",
+  "model": "gpt-4o-mini",
+  "fallbackModel": "gpt-4o",
+  "fallbackUsed": true,
+  "dryRun": false,
+  "sourceLanguage": "ru",
+  "targetLanguages": ["en"],
+  "files": {"selected": 12, "skipped": 3},
+  "totals": {
+    "files": {"translated": 12, "failed": 0, "retried": 1},
+    "units": {"total": 340, "translated": 182, "fromCache": 154, "untranslated": 4, "oversized": 0},
+    "chars": {"source": 15200, "translated": 16900, "request": 8300},
+    "tokens": {"input": 5200, "output": 4800},
+    "requests": {"total": 18, "fallback": 2, "retries": 3},
+    "cache": {"enabled": true, "hits": 154, "misses": 186, "hitRate": 0.4529}
+  },
+  "targets": [
+    {
+      "language": "en",
+      "files": {"translated": 12, "failed": 0, "retried": 1},
+      "units": {
+        "total": 340,
+        "translated": 182,
+        "fromCache": 154,
+        "untranslated": 4,
+        "oversized": 0
+      },
+      "chars": {"source": 15200, "translated": 16900, "request": 8300},
+      "tokens": {"input": 5200, "output": 4800},
+      "requests": {"total": 18, "fallback": 2, "retries": 3},
+      "cache": {"enabled": true, "hits": 154, "misses": 186, "hitRate": 0.4529},
+      "judge": {
+        "model": "gpt-4o",
+        "threshold": 70,
+        "scored": 182,
+        "averageScore": 91.4,
+        "belowThreshold": 5,
+        "unscored": 0,
+        "distribution": {
+          "0-9": 0,
+          "10-19": 0,
+          "20-29": 0,
+          "30-39": 0,
+          "40-49": 1,
+          "50-59": 1,
+          "60-69": 3,
+          "70-79": 12,
+          "80-89": 40,
+          "90-99": 95,
+          "100": 30
+        }
+      }
+    }
+  ],
+  "errors": []
+}
+```
+
+## Relation to the judge quality report
+
+`--judge` also writes a standalone quality report
+(`translate-quality.<lang>.json` in the output directory) with per-segment
+verdicts. The run report duplicates only its aggregate stats; per-segment
+details stay in the quality report.

--- a/src/commands/translate/commands/seed.spec.ts
+++ b/src/commands/translate/commands/seed.spec.ts
@@ -10,6 +10,7 @@ import {describe, expect, it, vi} from 'vitest';
 
 import {makeStore, makeTranslator} from '../providers/ai/provider';
 import {SeedStore, seedFilePath} from '../providers/ai/utils';
+import {createTargetStat} from '../report';
 import {loadTranslationUnits} from '../utils';
 
 import {seedTranslations} from './seed';
@@ -149,15 +150,7 @@ describe('translate seed', () => {
             const store = makeStore(client, config, 'ru', 'en');
             store?.load();
 
-            const stat = {
-                inputTokens: 0,
-                outputTokens: 0,
-                requests: 0,
-                bytes: 0,
-                cached: 0,
-                untranslated: 0,
-                fallbackRequests: 0,
-            };
+            const stat = createTargetStat();
             const translate = makeTranslator({
                 client,
                 config,

--- a/src/commands/translate/config.ts
+++ b/src/commands/translate/config.ts
@@ -143,6 +143,21 @@ const copyAssets = option({
     `,
 });
 
+const report = option({
+    flags: '--report <path>',
+    desc: `
+        Write a machine-readable JSON report of the translation run to the
+        given path: timings, volume (files, units, characters, tokens),
+        cache and fallback usage, judge scores and errors.
+
+        The report schema is versioned (see the schemaVersion field).
+        Disabled by default. A short run summary is always logged.
+
+        Example:
+          {{PROGRAM}} --report ./translate-report.json
+    `,
+});
+
 const useSource = option({
     flags: '--use-source',
     desc: `
@@ -205,6 +220,7 @@ export const options = {
     dryRun,
     copyAssets,
     timeout,
+    report,
     useSource,
     schema,
     filter,

--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -1,6 +1,7 @@
 import type {YandexTranslationConfig} from './providers/yandex';
 import type {AITranslationConfig} from './providers/ai';
 
+import {resolve} from 'node:path';
 import {describe, expect, it, vi} from 'vitest';
 import {filter} from 'minimatch';
 
@@ -302,6 +303,30 @@ describe('Translate command', () => {
                 },
                 {
                     copyAssets: true,
+                },
+            );
+        });
+
+        describe('report', () => {
+            const test = testConfig('--source ru --target en --folder 1 --auth t1.a');
+
+            test('should be disabled by default', '', {
+                report: undefined,
+            });
+
+            test('should resolve arg path from cwd', '--report reports/run.json', {
+                report: resolve('reports/run.json'),
+            });
+
+            test(
+                'should handle config',
+                '',
+                {
+                    // @ts-ignore
+                    report: 'run.json',
+                },
+                {
+                    report: expect.stringContaining('run.json'),
                 },
             );
         });

--- a/src/commands/translate/index.ts
+++ b/src/commands/translate/index.ts
@@ -3,6 +3,7 @@ import type {Locale} from './utils';
 import type {ConfigDefaults} from './utils/config';
 
 import {ok} from 'assert';
+import {resolve} from 'node:path';
 import {pick} from 'lodash';
 import {escape as escapeGlob} from 'minimatch';
 
@@ -14,6 +15,7 @@ import {
 } from '~/core/program';
 import {Command, args, defined} from '~/core/config';
 import {YFM_CONFIG_FILENAME} from '~/constants';
+import {own} from '~/core/utils';
 
 import {getHooks, withHooks} from './hooks';
 import {DESCRIPTION, NAME, options} from './config';
@@ -28,6 +30,15 @@ import {configDefaults} from './utils/config';
 import {Extension as ExtractOpenapiIncluderFakeExtension} from './extract-openapi';
 
 export {getHooks};
+export {TRANSLATE_REPORT_SCHEMA_VERSION} from './report';
+export type {
+    TranslateRunReport,
+    TranslateReportStatus,
+    TranslateReportCounters,
+    TranslateReportTarget,
+    TranslateReportJudge,
+    TranslateReportError,
+} from './report';
 
 export interface IProvider {
     skip(files: [string, string][], config: TranslateConfig): Promise<void>;
@@ -44,6 +55,7 @@ export type TranslateArgs = BaseArgs & {
     includeVcsDiff?: string | boolean;
     vars?: Hash;
     copyAssets?: boolean;
+    report?: string;
 };
 
 export type TranslateConfig = Pick<BaseArgs, 'input' | 'strict' | 'quiet'> & {
@@ -60,6 +72,8 @@ export type TranslateConfig = Pick<BaseArgs, 'input' | 'strict' | 'quiet'> & {
     dryRun: boolean;
     copyAssets: boolean;
     timeout: number;
+    /** Absolute path of the JSON run report. Not written when unset. */
+    report?: AbsolutePath;
 } & ConfigDefaults;
 
 @withHooks
@@ -87,6 +101,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
         options.dryRun,
         options.copyAssets,
         options.timeout,
+        options.report,
         options.config(YFM_CONFIG_FILENAME),
     ];
 
@@ -129,6 +144,16 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
             const files = defined('files', args, config);
             const vars = resolveVars(config, args);
 
+            // CLI report paths are resolved from cwd, config values from the config dir.
+            let report: AbsolutePath | undefined;
+            if (own<string, 'report'>(args, 'report')) {
+                report = resolve(args.report) as AbsolutePath;
+            } else if (own<string, 'report'>(config, 'report')) {
+                report = config.resolve
+                    ? config.resolve(config.report)
+                    : (resolve(config.report) as AbsolutePath);
+            }
+
             return Object.assign(config, {
                 input,
                 output: output || input,
@@ -144,6 +169,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
                 provider: defined('provider', args, config),
                 dryRun: defined('dryRun', args, config) || false,
                 copyAssets: defined('copyAssets', args, config) || false,
+                report,
                 // No global default here: each provider applies its own
                 // (5s for yandex, 60s for LLM providers).
                 timeout: defined('timeout', args, config) as number,

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -8,6 +8,8 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, expect, it, vi} from 'vitest';
 
+import {createTargetStat} from '../../report';
+
 import {
     Provider,
     extractTitle,
@@ -59,15 +61,7 @@ function makeParams(
 ) {
     const warn = vi.fn();
     const request = vi.fn();
-    const stat = {
-        inputTokens: 0,
-        outputTokens: 0,
-        requests: 0,
-        bytes: 0,
-        cached: 0,
-        untranslated: 0,
-        fallbackRequests: 0,
-    };
+    const stat = createTargetStat();
     const cache = new Map<string, Defer>();
 
     return {
@@ -176,6 +170,154 @@ describe('translate ai provider', () => {
             expect(report.scored).toBeGreaterThan(0);
             expect(report.low).toBeGreaterThan(0);
             expect(logger.warn).toHaveBeenCalledWith('ru/test.md', expect.stringContaining('/100'));
+        });
+
+        it('should write a machine-readable run report when configured', async () => {
+            const root = mkdtempSync(join(tmpdir(), 'yfm-ai-report-'));
+            const input = join(root, 'docs');
+            const output = join(root, 'out');
+            mkdirSync(join(input, 'ru'), {recursive: true});
+            writeFileSync(join(input, 'ru', 'test.md'), '# Заголовок\n\nПривет, мир.\n');
+
+            const inner = makeFullClient();
+            const client: LLMClient = {
+                name: 'fake',
+                complete: vi.fn(async (messages, options) => {
+                    const result = await inner.complete(messages, options);
+                    return {...result, usage: {inputTokens: 10, outputTokens: 12}};
+                }),
+            };
+
+            const reportPath = join(root, 'stats', 'report.json');
+            const provider = new Provider(() => client, {} as never);
+            const logger = {
+                translate: vi.fn(),
+                translated: vi.fn(),
+                request: vi.fn(),
+                stat: vi.fn(),
+                warn: vi.fn(),
+                error: vi.fn(),
+                skipped: vi.fn(),
+            };
+            Object.assign(provider, {logger});
+
+            await provider.skip([['not-matched', 'ru/skipped.md']]);
+            await provider.translate(['ru/test.md'], {
+                provider: 'openai',
+                model: 'test-model',
+                input,
+                output,
+                source: {language: 'ru', locale: 'RU'},
+                target: [{language: 'en', locale: 'US'}],
+                vars: {},
+                dryRun: false,
+                judge: true,
+                judgeThreshold: 80,
+                userPrompt: '{{fragments}}',
+                promptMode: 'append',
+                glossaryPairs: [],
+                temperature: 0,
+                maxOutputTokens: 200,
+                maxBatchTokens: 100,
+                maxConcurrency: 2,
+                retry: 0,
+                report: reportPath,
+            } as unknown as AITranslationConfig);
+
+            const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+
+            expect(report.schemaVersion).toBe(1);
+            expect(report.status).toBe('success');
+            expect(report.provider).toBe('openai');
+            expect(report.model).toBe('test-model');
+            expect(report.fallbackUsed).toBe(false);
+            expect(report.dryRun).toBe(false);
+            expect(report.sourceLanguage).toBe('ru');
+            expect(report.targetLanguages).toEqual(['en']);
+            expect(report.files).toEqual({selected: 1, skipped: 1});
+            expect(report.durationMs).toBeGreaterThanOrEqual(0);
+            expect(report.errors).toEqual([]);
+
+            const target = report.targets[0];
+            expect(target.language).toBe('en');
+            expect(target.files.translated).toBe(1);
+            expect(target.units.total).toBe(2);
+            expect(target.units.translated).toBe(2);
+            expect(target.chars.source).toBeGreaterThan(0);
+            expect(target.chars.translated).toBeGreaterThan(0);
+            expect(target.tokens.input).toBeGreaterThan(0);
+            expect(target.tokens.output).toBeGreaterThan(0);
+            expect(target.cache).toEqual({enabled: false, hits: 0, misses: 0, hitRate: null});
+            expect(target.judge.scored).toBe(2);
+            expect(target.judge.threshold).toBe(80);
+            expect(target.judge.belowThreshold).toBe(2);
+            expect(Object.keys(target.judge.distribution)).toHaveLength(11);
+
+            expect(logger.stat).toHaveBeenCalledWith(expect.stringContaining('run success'));
+        });
+
+        it('should record errors in the run report and mark the run partial', async () => {
+            const root = mkdtempSync(join(tmpdir(), 'yfm-ai-report-err-'));
+            const input = join(root, 'docs');
+            const output = join(root, 'out');
+            mkdirSync(join(input, 'ru'), {recursive: true});
+            writeFileSync(join(input, 'ru', 'test.md'), 'Привет, мир.\n');
+
+            const client: LLMClient = {
+                name: 'fake',
+                complete: vi.fn(async () => {
+                    throw new LLMRateLimitError('Too Many Requests');
+                }),
+            };
+
+            const reportPath = join(root, 'report.json');
+            const provider = new Provider(() => client, {} as never);
+            const logger = {
+                translate: vi.fn(),
+                translated: vi.fn(),
+                request: vi.fn(),
+                stat: vi.fn(),
+                info: vi.fn(),
+                warn: vi.fn(),
+                error: vi.fn(),
+            };
+            Object.assign(provider, {logger});
+
+            await provider.translate(['ru/test.md'], {
+                provider: 'openai',
+                model: 'test-model',
+                input,
+                output,
+                source: {language: 'ru', locale: 'RU'},
+                target: [{language: 'en', locale: 'US'}],
+                vars: {},
+                dryRun: false,
+                judge: false,
+                userPrompt: '{{fragments}}',
+                promptMode: 'append',
+                glossaryPairs: [],
+                temperature: 0,
+                maxOutputTokens: 200,
+                maxBatchTokens: 100,
+                maxConcurrency: 2,
+                retry: 0,
+                report: reportPath,
+            } as unknown as AITranslationConfig);
+
+            const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+
+            expect(report.status).toBe('partial');
+            expect(report.errors).toEqual([
+                {
+                    target: 'en',
+                    path: 'ru/test.md',
+                    code: 'LLM_RATE_LIMIT',
+                    message: 'Too Many Requests',
+                },
+            ]);
+            expect(report.targets[0].files.failed).toBe(1);
+            expect(report.targets[0].files.retried).toBe(1);
+            expect(logger.stat).toHaveBeenCalledWith(expect.stringContaining('run partial'));
         });
 
         it('should retry files that failed with transient errors after the main pass', async () => {
@@ -591,6 +733,40 @@ describe('translate ai provider', () => {
             expect(client.complete).toHaveBeenCalledTimes(2);
         });
 
+        it('should count report counters for units, chars and the cache', async () => {
+            const root = mkdtempSync(join(tmpdir(), 'yfm-ai-stat-'));
+            const store = new TranslationStore(join(root, 'cache.json'), 'fp');
+            store.set('Cached', 'T:Cached');
+
+            const client = makeClient(translated);
+            const {params, stat} = makeParams(client, {}, store);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['Cached', 'Fresh', 'Fresh']);
+
+            expect(result).toEqual(['T:Cached', 'T:Fresh', 'T:Fresh']);
+            expect(stat.unitsTotal).toBe(3);
+            expect(stat.sourceChars).toBe('Cached'.length + 'Fresh'.length * 2);
+            expect(stat.cached).toBe(1);
+            // Both occurrences of the fresh unit miss the store: the second
+            // one is deduped via the in-flight map, not the persistent cache.
+            expect(stat.cacheMisses).toBe(2);
+            expect(stat.translatedUnits).toBe(1);
+            expect(stat.translatedChars).toBe('T:Fresh'.length);
+        });
+
+        it('should not count cache misses when the store is disabled', async () => {
+            const client = makeClient(translated);
+            const {params, stat} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            await translate('file.md', ['One', 'Two']);
+
+            expect(stat.cacheMisses).toBe(0);
+            expect(stat.cached).toBe(0);
+            expect(stat.unitsTotal).toBe(2);
+        });
+
         it('should dedupe repeated units via cache', async () => {
             const client = makeClient(translated);
             const {params} = makeParams(client);
@@ -719,7 +895,7 @@ describe('translate ai provider', () => {
                 const client = makeClient((fragments, call) =>
                     call === 0 ? new LLMRateLimitError('slow down') : translated(fragments),
                 );
-                const {params} = makeParams(client, {retry: 0, rateLimitRetry: 1});
+                const {params, stat} = makeParams(client, {retry: 0, rateLimitRetry: 1});
                 const translate = makeTranslator(params);
 
                 const promise = translate('file.md', ['One']);
@@ -729,6 +905,8 @@ describe('translate ai provider', () => {
                 await success;
 
                 expect(client.complete).toHaveBeenCalledTimes(2);
+                expect(stat.retries).toBe(1);
+                expect(stat.requests).toBe(1);
             } finally {
                 vi.useRealTimers();
             }

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -14,7 +14,7 @@ import {isFenceClose, matchFenceOpen} from '~/core/utils';
 
 import {TranslateError, compose, languageRepath, loadTranslationUnits} from '../../utils';
 import {TranslateLogger} from '../../logger';
-import {RunReport, createTargetStat, scoreDistribution} from '../../report';
+import {RunReport, createTargetStat, reportError, scoreDistribution} from '../../report';
 
 import {
     Defer,
@@ -70,16 +70,7 @@ export class Provider {
             : undefined;
         const {input, output, source, target: targets, vars, dryRun, maxConcurrency} = config;
 
-        this.report = new RunReport({
-            provider: config.provider,
-            model: config.model,
-            fallbackModel: config.fallbackModel,
-            dryRun,
-            sourceLanguage: source.language,
-            targetLanguages: targets.map((target) => target.language),
-            path: config.report,
-        });
-        this.report.setFiles(files.length, this.skippedFiles);
+        this.report = RunReport.start(config, files.length, this.skippedFiles);
 
         try {
             for (const target of targets) {
@@ -141,7 +132,7 @@ export class Provider {
                 this.report.addTarget(target.language, stat, judge);
             }
 
-            this.finishReport();
+            this.report.close(this.logger);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (error instanceof TranslateError) {
@@ -149,33 +140,10 @@ export class Provider {
             } else {
                 this.logger.error(error);
             }
-            this.report.addError({
-                code: error instanceof TranslateError ? error.code : 'UNKNOWN',
-                message: String(error?.message || error),
-            });
-            this.finishReport('failed');
+            this.report.addError(reportError(error));
+            this.report.close(this.logger, 'failed');
             process.exit(1);
         }
-    }
-
-    /**
-     * Finalizes the run report, writes it when --report is configured and
-     * always logs the one-line run summary. Report IO failures must not
-     * fail the translation run.
-     */
-    private finishReport(status?: 'failed') {
-        if (!this.report) {
-            return;
-        }
-
-        this.report.finalize(status);
-        try {
-            this.report.write();
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            this.logger.warn('report', `Unable to write the run report: ${error.message}`);
-        }
-        this.logger.stat(this.report.summary());
     }
 
     /**
@@ -245,17 +213,12 @@ export class Provider {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private reportFileError(file: string, error: any, stat: TargetStat, target: string) {
         stat.filesFailed++;
-        this.report?.addError({
-            target,
-            path: file,
-            code: error instanceof TranslateError ? error.code : 'UNKNOWN',
-            message: String(error?.message || error),
-        });
+        this.report?.addError(reportError(error, {target, path: file}));
 
         if (error instanceof TranslateError) {
             this.logger.error(file, `${error.message}`, error.code);
             if (error.fatal) {
-                this.finishReport('failed');
+                this.report?.close(this.logger, 'failed');
                 onFatalError();
             }
         } else {

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -3,6 +3,7 @@ import type {TranslateConfig} from '~/commands/translate';
 import type {AITranslationConfig} from './index';
 import type {CompletionResult, LLMClient} from './clients/types';
 import type {JudgePair} from './judge';
+import type {TargetStat, TranslateReportJudge} from '../../report';
 
 import {writeFile} from 'node:fs/promises';
 import {extname, join, resolve} from 'node:path';
@@ -13,6 +14,7 @@ import {isFenceClose, matchFenceOpen} from '~/core/utils';
 
 import {TranslateError, compose, languageRepath, loadTranslationUnits} from '../../utils';
 import {TranslateLogger} from '../../logger';
+import {RunReport, createTargetStat, scoreDistribution} from '../../report';
 
 import {
     Defer,
@@ -43,6 +45,10 @@ export class Provider {
 
     private readonly clientFactory: ClientFactory;
 
+    private report?: RunReport;
+
+    private skippedFiles = 0;
+
     constructor(clientFactory: ClientFactory, config: TranslateConfig) {
         this.clientFactory = clientFactory;
         this.logger = new TranslateLogger(config);
@@ -53,6 +59,7 @@ export class Provider {
     }
 
     async skip(skipped: [string, string][]) {
+        this.skippedFiles = skipped.length;
         this.logger.skipped(skipped);
     }
 
@@ -63,20 +70,24 @@ export class Provider {
             : undefined;
         const {input, output, source, target: targets, vars, dryRun, maxConcurrency} = config;
 
+        this.report = new RunReport({
+            provider: config.provider,
+            model: config.model,
+            fallbackModel: config.fallbackModel,
+            dryRun,
+            sourceLanguage: source.language,
+            targetLanguages: targets.map((target) => target.language),
+            path: config.report,
+        });
+        this.report.setFiles(files.length, this.skippedFiles);
+
         try {
             for (const target of targets) {
                 const cache = new Map<string, Defer>();
-                const stat = {
-                    inputTokens: 0,
-                    outputTokens: 0,
-                    requests: 0,
-                    bytes: 0,
-                    cached: 0,
-                    untranslated: 0,
-                    fallbackRequests: 0,
-                };
+                const stat = createTargetStat();
                 const store = makeStore(client, config, source.language, target.language);
 
+                stat.cacheEnabled = Boolean(store);
                 store?.load();
 
                 const translate = makeTranslator({
@@ -104,7 +115,15 @@ export class Provider {
                     onTranslated: collect,
                 });
 
-                await this.processFiles({files, maxConcurrency, dryRun, store, processFile});
+                await this.processFiles({
+                    files,
+                    maxConcurrency,
+                    dryRun,
+                    store,
+                    processFile,
+                    stat,
+                    target: target.language,
+                });
 
                 store?.flush();
 
@@ -115,10 +134,14 @@ export class Provider {
                         (fallbackClient ? ` fallback-requests: ${stat.fallbackRequests}` : ''),
                 );
 
-                if (pairs.length) {
-                    await this.judge(pairs, config, source.language, target.language);
-                }
+                const judge = pairs.length
+                    ? await this.judge(pairs, config, source.language, target.language)
+                    : undefined;
+
+                this.report.addTarget(target.language, stat, judge);
             }
+
+            this.finishReport();
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (error instanceof TranslateError) {
@@ -126,8 +149,33 @@ export class Provider {
             } else {
                 this.logger.error(error);
             }
+            this.report.addError({
+                code: error instanceof TranslateError ? error.code : 'UNKNOWN',
+                message: String(error?.message || error),
+            });
+            this.finishReport('failed');
             process.exit(1);
         }
+    }
+
+    /**
+     * Finalizes the run report, writes it when --report is configured and
+     * always logs the one-line run summary. Report IO failures must not
+     * fail the translation run.
+     */
+    private finishReport(status?: 'failed') {
+        if (!this.report) {
+            return;
+        }
+
+        this.report.finalize(status);
+        try {
+            this.report.write();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            this.logger.warn('report', `Unable to write the run report: ${error.message}`);
+        }
+        this.logger.stat(this.report.summary());
     }
 
     /**
@@ -142,8 +190,10 @@ export class Provider {
         dryRun: boolean;
         store?: TranslationStore;
         processFile: (file: string) => Promise<void>;
+        stat: TargetStat;
+        target: string;
     }) {
-        const {files, maxConcurrency, dryRun, store, processFile} = params;
+        const {files, maxConcurrency, dryRun, store, processFile, stat, target} = params;
         const failed: string[] = [];
 
         const run = async (file: string, finalPass: boolean) => {
@@ -152,6 +202,7 @@ export class Provider {
                 await processFile(file);
                 // Flush after every file to keep progress on crashes.
                 store?.flush();
+                stat.filesTranslated++;
                 if (!dryRun) {
                     this.logger.translated(file);
                 }
@@ -162,13 +213,14 @@ export class Provider {
                 // queue the file for one final sweep.
                 if (!finalPass && error?.retryable === true) {
                     failed.push(file);
+                    stat.filesRetried++;
                     this.logger.warn(
                         file,
                         `${error.message}; the file will be retried after the main pass.`,
                     );
                     return;
                 }
-                this.reportFileError(file, error);
+                this.reportFileError(file, error, stat, target);
             }
         };
 
@@ -191,10 +243,19 @@ export class Provider {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private reportFileError(file: string, error: any) {
+    private reportFileError(file: string, error: any, stat: TargetStat, target: string) {
+        stat.filesFailed++;
+        this.report?.addError({
+            target,
+            path: file,
+            code: error instanceof TranslateError ? error.code : 'UNKNOWN',
+            message: String(error?.message || error),
+        });
+
         if (error instanceof TranslateError) {
             this.logger.error(file, `${error.message}`, error.code);
             if (error.fatal) {
+                this.finishReport('failed');
                 onFatalError();
             }
         } else {
@@ -212,7 +273,7 @@ export class Provider {
         config: AITranslationConfig,
         sourceLanguage: string,
         targetLanguage: string,
-    ) {
+    ): Promise<TranslateReportJudge> {
         const client = this.clientFactory(
             config.judgeModel ? {...config, model: config.judgeModel} : config,
         );
@@ -276,6 +337,16 @@ export class Provider {
                 (skippedPairs ? `, ${skippedPairs} pair(s) unscored` : '') +
                 ` (${report})`,
         );
+
+        return {
+            model: config.judgeModel || config.model,
+            threshold,
+            scored: verdicts.length,
+            averageScore: average,
+            belowThreshold: low.length,
+            unscored: skippedPairs,
+            distribution: scoreDistribution(verdicts.map((verdict) => verdict.score)),
+        };
     }
 }
 
@@ -420,15 +491,7 @@ type TranslatorParams = {
     targetLanguage: string;
     cache: Map<string, Defer>;
     store?: TranslationStore;
-    stat: {
-        inputTokens: number;
-        outputTokens: number;
-        requests: number;
-        bytes: number;
-        cached: number;
-        untranslated: number;
-        fallbackRequests: number;
-    };
+    stat: TargetStat;
     logger: TranslateLogger;
 };
 
@@ -653,15 +716,30 @@ export function makeTranslator(params: TranslatorParams): Translate {
             const inputTokens = messages.reduce((sum, m) => sum + estimateTokens(m.content), 0);
             stat.inputTokens += inputTokens;
             stat.outputTokens += fragments.reduce((sum, f) => sum + estimateTokens(f), 0);
+            // Dry-run tokens are estimates, but they are the point of the
+            // mode (quota planning) - surface them in the report too.
+            stat.usageSeen = true;
             stat.requests++;
             stat.bytes += bytes(fragments);
             return fragments;
         }
 
+        // Every attempt after the first one is a retry, on success and on
+        // final failure alike - count them where the requests happen.
+        const counted = <T>(action: () => Promise<T>) => {
+            let attempts = 0;
+            return () => {
+                if (attempts++) {
+                    stat.retries++;
+                }
+                return action();
+            };
+        };
+
         let result: CompletionResult;
         try {
             result = await backoff(
-                () => client.complete(messages, {temperature, maxTokens: maxOutputTokens}),
+                counted(() => client.complete(messages, {temperature, maxTokens: maxOutputTokens})),
                 retry,
                 {rateLimitRetries: rateLimitRetry, gate},
             );
@@ -677,7 +755,9 @@ export function makeTranslator(params: TranslatorParams): Translate {
                 `Primary model failed (${error.message}); retrying with the fallback model.`,
             );
             result = await backoff(
-                () => fallbackClient.complete(messages, {temperature, maxTokens: maxOutputTokens}),
+                counted(() =>
+                    fallbackClient.complete(messages, {temperature, maxTokens: maxOutputTokens}),
+                ),
                 retry,
                 {rateLimitRetries: rateLimitRetry, gate: fallbackGate},
             );
@@ -687,6 +767,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
         stat.requests++;
         stat.bytes += bytes(fragments);
         if (result.usage) {
+            stat.usageSeen = true;
             stat.inputTokens += result.usage.inputTokens;
             stat.outputTokens += result.usage.outputTokens;
         }
@@ -773,6 +854,8 @@ export function makeTranslator(params: TranslatorParams): Translate {
                                 cache.get(batch[i])?.resolve(text);
                                 return;
                             }
+                            stat.translatedUnits++;
+                            stat.translatedChars += text.length;
                             cache.get(batch[i])?.resolve(text);
                             if (!dryRun) {
                                 store?.set(batch[i], text);
@@ -799,11 +882,15 @@ export function makeTranslator(params: TranslatorParams): Translate {
         for (const text of texts) {
             const tokens = estimateTokens(text);
 
+            stat.unitsTotal++;
+            stat.sourceChars += text.length;
+
             if (tokens > maxBatchTokens) {
                 logger.warn(
                     path,
                     `Skip document part for translation. Part is too big (~${tokens} tokens > ${maxBatchTokens}).`,
                 );
+                stat.oversized++;
                 promises.push(Promise.resolve(text));
                 continue;
             }
@@ -824,6 +911,10 @@ export function makeTranslator(params: TranslatorParams): Translate {
                     promises.push(Promise.resolve(normalized));
                     continue;
                 }
+            }
+
+            if (store) {
+                stat.cacheMisses++;
             }
 
             const cached = cache.get(text);

--- a/src/commands/translate/providers/yandex/provider.ts
+++ b/src/commands/translate/providers/yandex/provider.ts
@@ -20,7 +20,7 @@ import {
     resolveSchemas,
 } from '../../utils';
 import {TranslateLogger} from '../../logger';
-import {RunReport, createTargetStat} from '../../report';
+import {RunReport, createTargetStat, reportError} from '../../report';
 
 import {AuthError, Defer, LimitExceed, RequestError, bytes} from './utils';
 
@@ -65,14 +65,7 @@ export class Provider {
             timeout,
         } = config;
 
-        this.report = new RunReport({
-            provider: config.provider,
-            dryRun,
-            sourceLanguage: source.language,
-            targetLanguages: targets.map((target) => target.language),
-            path: config.report,
-        });
-        this.report.setFiles(files.length, this.skippedFiles);
+        this.report = RunReport.start(config, files.length, this.skippedFiles);
 
         try {
             for (const target of targets) {
@@ -109,18 +102,15 @@ export class Provider {
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         } catch (error: any) {
                             stat.filesFailed++;
-                            this.report?.addError({
-                                target: target.language,
-                                path: file,
-                                code: error instanceof TranslateError ? error.code : 'UNKNOWN',
-                                message: String(error?.message || error),
-                            });
+                            this.report?.addError(
+                                reportError(error, {target: target.language, path: file}),
+                            );
 
                             if (error instanceof TranslateError) {
                                 this.logger.error(file, `${error.message}`, error.code);
 
                                 if (error.fatal) {
-                                    this.finishReport('failed');
+                                    this.report?.close(this.logger, 'failed');
                                     onFatalError();
                                 }
                             } else {
@@ -135,7 +125,7 @@ export class Provider {
                 this.report.addTarget(target.language, stat);
             }
 
-            this.finishReport();
+            this.report.close(this.logger);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (error instanceof TranslateError) {
@@ -144,33 +134,10 @@ export class Provider {
                 this.logger.error(error);
             }
 
-            this.report.addError({
-                code: error instanceof TranslateError ? error.code : 'UNKNOWN',
-                message: String(error?.message || error),
-            });
-            this.finishReport('failed');
+            this.report.addError(reportError(error));
+            this.report.close(this.logger, 'failed');
             process.exit(1);
         }
-    }
-
-    /**
-     * Finalizes the run report, writes it when --report is configured and
-     * always logs the one-line run summary. Report IO failures must not
-     * fail the translation run.
-     */
-    private finishReport(status?: 'failed') {
-        if (!this.report) {
-            return;
-        }
-
-        this.report.finalize(status);
-        try {
-            this.report.write();
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            this.logger.warn('report', `Unable to write the run report: ${error.message}`);
-        }
-        this.logger.stat(this.report.summary());
     }
 }
 

--- a/src/commands/translate/providers/yandex/provider.ts
+++ b/src/commands/translate/providers/yandex/provider.ts
@@ -2,6 +2,7 @@ import type {TranslateConfig} from '~/commands/translate';
 import type {YandexTranslationConfig} from '.';
 import type {AxiosResponse} from 'axios';
 import type {Logger} from '~/core/logger';
+import type {TargetStat} from '../../report';
 
 import {extname, join, resolve} from 'node:path';
 import {asyncify, eachLimit} from 'async';
@@ -19,6 +20,7 @@ import {
     resolveSchemas,
 } from '../../utils';
 import {TranslateLogger} from '../../logger';
+import {RunReport, createTargetStat} from '../../report';
 
 import {AuthError, Defer, LimitExceed, RequestError, bytes} from './utils';
 
@@ -33,6 +35,10 @@ const onFatalError = () => {
 export class Provider {
     readonly logger: TranslateLogger;
 
+    private report?: RunReport;
+
+    private skippedFiles = 0;
+
     constructor(config: TranslateConfig) {
         this.logger = new TranslateLogger(config);
     }
@@ -42,6 +48,7 @@ export class Provider {
     }
 
     async skip(skipped: [string, string][]) {
+        this.skippedFiles = skipped.length;
         this.logger.skipped(skipped);
     }
 
@@ -57,6 +64,15 @@ export class Provider {
             dryRun,
             timeout,
         } = config;
+
+        this.report = new RunReport({
+            provider: config.provider,
+            dryRun,
+            sourceLanguage: source.language,
+            targetLanguages: targets.map((target) => target.language),
+            path: config.report,
+        });
+        this.report.setFiles(files.length, this.skippedFiles);
 
         try {
             for (const target of targets) {
@@ -74,8 +90,9 @@ export class Provider {
                 };
 
                 const cache = new Map<string, Defer>();
-                const request = requester(translatorParams, cache);
-                const translate = translator(request, cache, this.logger);
+                const stat = createTargetStat();
+                const request = requester(translatorParams, cache, stat);
+                const translate = translator(request, cache, this.logger, stat);
                 const process = processor(translatorParams, translate);
 
                 await eachLimit(
@@ -85,15 +102,25 @@ export class Provider {
                         try {
                             this.logger.translate(file);
                             await process(file);
+                            stat.filesTranslated++;
                             if (!dryRun) {
                                 this.logger.translated(file);
                             }
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         } catch (error: any) {
+                            stat.filesFailed++;
+                            this.report?.addError({
+                                target: target.language,
+                                path: file,
+                                code: error instanceof TranslateError ? error.code : 'UNKNOWN',
+                                message: String(error?.message || error),
+                            });
+
                             if (error instanceof TranslateError) {
                                 this.logger.error(file, `${error.message}`, error.code);
 
                                 if (error.fatal) {
+                                    this.finishReport('failed');
                                     onFatalError();
                                 }
                             } else {
@@ -103,8 +130,12 @@ export class Provider {
                     }),
                 );
 
-                this.logger.stat(`bytes: ${request.stat.bytes} chunks: ${request.stat.chunks}`);
+                this.logger.stat(`bytes: ${stat.bytes} chunks: ${stat.requests}`);
+
+                this.report.addTarget(target.language, stat);
             }
+
+            this.finishReport();
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (error instanceof TranslateError) {
@@ -113,8 +144,33 @@ export class Provider {
                 this.logger.error(error);
             }
 
+            this.report.addError({
+                code: error instanceof TranslateError ? error.code : 'UNKNOWN',
+                message: String(error?.message || error),
+            });
+            this.finishReport('failed');
             process.exit(1);
         }
+    }
+
+    /**
+     * Finalizes the run report, writes it when --report is configured and
+     * always logs the one-line run summary. Report IO failures must not
+     * fail the translation run.
+     */
+    private finishReport(status?: 'failed') {
+        if (!this.report) {
+            return;
+        }
+
+        this.report.finalize(status);
+        try {
+            this.report.write();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            this.logger.warn('report', `Unable to write the run report: ${error.message}`);
+        }
+        this.logger.stat(this.report.summary());
     }
 }
 
@@ -136,13 +192,7 @@ type RequesterParams = {
     timeout: number;
 };
 
-type Request = {
-    (texts: string[]): () => Promise<void>;
-    stat: {
-        bytes: number;
-        chunks: number;
-    };
-};
+type Request = (texts: string[]) => () => Promise<void>;
 
 type Translate = (path: string, texts: string[]) => Promise<string[]>;
 
@@ -189,20 +239,30 @@ function scheduler(limit: number, interval: number) {
     };
 }
 
-function requester(params: RequesterParams, cache: Cache) {
+function requester(params: RequesterParams, cache: Cache, stat: TargetStat): Request {
     const {auth, folderId, sourceLanguage, targetLanguage, dryRun, timeout} = params;
     const schedule = scheduler(REQUESTS_LIMIT, 1000);
 
-    const request = function request(texts: string[]) {
+    return function request(texts: string[]) {
+        // The backoff loop may run the request action more than once -
+        // resolve (and count) every unit at most once per chunk.
+        const resolved = new Set<number>();
         const resolve = (text: string, index: number) => {
+            if (resolved.has(index)) {
+                return;
+            }
+            resolved.add(index);
+
             const defer = cache.get(texts[index]);
             if (defer) {
+                stat.translatedUnits++;
+                stat.translatedChars += text.length;
                 defer.resolve(text);
             }
         };
 
-        request.stat.bytes += bytes(texts);
-        request.stat.chunks++;
+        stat.bytes += bytes(texts);
+        stat.requests++;
 
         return async function () {
             if (dryRun) {
@@ -261,13 +321,6 @@ function requester(params: RequesterParams, cache: Cache) {
             }
         };
     };
-
-    request.stat = {
-        bytes: 0,
-        chunks: 0,
-    };
-
-    return request;
 }
 
 function processor(params: TranslatorParams, translate: Translate) {
@@ -331,7 +384,7 @@ function processor(params: TranslatorParams, translate: Translate) {
     };
 }
 
-function translator(request: Request, cache: Cache, logger: Logger): Translate {
+function translator(request: Request, cache: Cache, logger: Logger, stat: TargetStat): Translate {
     return async function (path: string, texts: string[]) {
         const promises: Promise<string>[] = [];
         const requests: Promise<void>[] = [];
@@ -339,14 +392,18 @@ function translator(request: Request, cache: Cache, logger: Logger): Translate {
         let bufferSize = 0;
 
         const release = () => {
-            requests.push(backoff(request(buffer)));
+            requests.push(backoff(request(buffer), stat));
             buffer = [];
             bufferSize = 0;
         };
 
         for (const text of texts) {
+            stat.unitsTotal++;
+            stat.sourceChars += text.length;
+
             if (text.length >= BYTES_LIMIT) {
                 logger.warn(path, 'Skip document part for translation. Part is too big.');
+                stat.oversized++;
                 promises.push(Promise.resolve(text));
             } else {
                 const defer = cache.get(text) || new Defer();
@@ -381,7 +438,7 @@ function wait(interval: number) {
     return defer.promise;
 }
 
-async function backoff(action: () => Promise<void>): Promise<void> {
+async function backoff(action: () => Promise<void>, stat: TargetStat): Promise<void> {
     let retry = 0;
 
     while (++retry < RETRY_LIMIT) {
@@ -390,6 +447,7 @@ async function backoff(action: () => Promise<void>): Promise<void> {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (RequestError.canRetry(error)) {
+                stat.retries++;
                 await wait(Math.pow(2, retry) * 1000);
             } else {
                 throw error;

--- a/src/commands/translate/report.spec.ts
+++ b/src/commands/translate/report.spec.ts
@@ -1,0 +1,208 @@
+import {mkdtempSync, readFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {describe, expect, it} from 'vitest';
+
+import {
+    RunReport,
+    TRANSLATE_REPORT_SCHEMA_VERSION,
+    createTargetStat,
+    scoreDistribution,
+} from './report';
+
+function makeReport(path?: AbsolutePath) {
+    return new RunReport({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        fallbackModel: 'gpt-4o',
+        dryRun: false,
+        sourceLanguage: 'ru',
+        targetLanguages: ['en'],
+        path,
+    });
+}
+
+describe('translate run report', () => {
+    describe('scoreDistribution', () => {
+        it('should build the full histogram with stable keys', () => {
+            const distribution = scoreDistribution([5, 15, 15, 95, 100, 100]);
+
+            expect(Object.keys(distribution)).toHaveLength(11);
+            expect(distribution['0-9']).toBe(1);
+            expect(distribution['10-19']).toBe(2);
+            expect(distribution['90-99']).toBe(1);
+            expect(distribution['100']).toBe(2);
+            expect(distribution['50-59']).toBe(0);
+        });
+    });
+
+    describe('RunReport', () => {
+        it('should map target stat into schema counters', () => {
+            const report = makeReport();
+            const stat = createTargetStat();
+
+            stat.unitsTotal = 10;
+            stat.translatedUnits = 6;
+            stat.cached = 3;
+            stat.cacheMisses = 7;
+            stat.cacheEnabled = true;
+            stat.untranslated = 1;
+            stat.oversized = 0;
+            stat.sourceChars = 1000;
+            stat.translatedChars = 1100;
+            stat.bytes = 700;
+            stat.requests = 4;
+            stat.fallbackRequests = 1;
+            stat.retries = 2;
+            stat.inputTokens = 500;
+            stat.outputTokens = 550;
+            stat.usageSeen = true;
+            stat.filesTranslated = 2;
+            stat.filesFailed = 1;
+            stat.filesRetried = 1;
+
+            report.setFiles(3, 1);
+            report.addTarget('en', stat);
+            const data = report.finalize();
+
+            expect(data.schemaVersion).toBe(TRANSLATE_REPORT_SCHEMA_VERSION);
+            expect(data.status).toBe('success');
+            expect(data.provider).toBe('openai');
+            expect(data.model).toBe('gpt-4o-mini');
+            expect(data.fallbackModel).toBe('gpt-4o');
+            expect(data.fallbackUsed).toBe(true);
+            expect(data.sourceLanguage).toBe('ru');
+            expect(data.targetLanguages).toEqual(['en']);
+            expect(data.files).toEqual({selected: 3, skipped: 1});
+            expect(data.durationMs).toBeGreaterThanOrEqual(0);
+            expect(Date.parse(data.startedAt)).toBeLessThanOrEqual(Date.parse(data.finishedAt));
+
+            const target = data.targets[0];
+            expect(target.language).toBe('en');
+            expect(target.files).toEqual({translated: 2, failed: 1, retried: 1});
+            expect(target.units).toEqual({
+                total: 10,
+                translated: 6,
+                fromCache: 3,
+                untranslated: 1,
+                oversized: 0,
+            });
+            expect(target.chars).toEqual({source: 1000, translated: 1100, request: 700});
+            expect(target.tokens).toEqual({input: 500, output: 550});
+            expect(target.requests).toEqual({total: 4, fallback: 1, retries: 2});
+            expect(target.cache).toEqual({enabled: true, hits: 3, misses: 7, hitRate: 0.3});
+
+            expect(data.totals.units.total).toBe(10);
+            expect(data.totals.cache.hitRate).toBe(0.3);
+        });
+
+        it('should sum totals across targets and keep tokens null when never reported', () => {
+            const report = makeReport();
+
+            const en = createTargetStat();
+            en.unitsTotal = 4;
+            en.translatedUnits = 4;
+            en.sourceChars = 100;
+
+            const de = createTargetStat();
+            de.unitsTotal = 6;
+            de.translatedUnits = 6;
+            de.sourceChars = 200;
+
+            report.addTarget('en', en);
+            report.addTarget('de', de);
+            const data = report.finalize();
+
+            expect(data.totals.units.total).toBe(10);
+            expect(data.totals.chars.source).toBe(300);
+            expect(data.totals.tokens).toBeNull();
+            expect(data.totals.cache).toEqual({
+                enabled: false,
+                hits: 0,
+                misses: 0,
+                hitRate: null,
+            });
+            expect(data.fallbackUsed).toBe(false);
+        });
+
+        it('should report partial status when errors were recorded', () => {
+            const report = makeReport();
+
+            report.addTarget('en', createTargetStat());
+            report.addError({
+                target: 'en',
+                path: 'ru/broken.md',
+                code: 'LLM_REQUEST_ERROR',
+                message: 'boom',
+            });
+
+            const data = report.finalize();
+
+            expect(data.status).toBe('partial');
+            expect(data.errors).toEqual([
+                {target: 'en', path: 'ru/broken.md', code: 'LLM_REQUEST_ERROR', message: 'boom'},
+            ]);
+        });
+
+        it('should report failed status when finalized as failed and stay idempotent', () => {
+            const report = makeReport();
+
+            const failed = report.finalize('failed');
+            expect(failed.status).toBe('failed');
+
+            // Later calls must not overwrite the fixed result.
+            expect(report.finalize().status).toBe('failed');
+        });
+
+        it('should attach judge stats to the target', () => {
+            const report = makeReport();
+            const judge = {
+                model: 'gpt-4o',
+                threshold: 70,
+                scored: 5,
+                averageScore: 88.5,
+                belowThreshold: 1,
+                unscored: 0,
+                distribution: scoreDistribution([60, 85, 90, 95, 100]),
+            };
+
+            report.addTarget('en', createTargetStat(), judge);
+
+            expect(report.finalize().targets[0].judge).toEqual(judge);
+        });
+
+        it('should write the report to the configured path', () => {
+            const root = mkdtempSync(join(tmpdir(), 'yfm-report-'));
+            const path = join(root, 'nested', 'report.json') as AbsolutePath;
+            const report = makeReport(path);
+
+            report.addTarget('en', createTargetStat());
+            report.finalize();
+            report.write();
+
+            const written = JSON.parse(readFileSync(path, 'utf8'));
+            expect(written.schemaVersion).toBe(TRANSLATE_REPORT_SCHEMA_VERSION);
+            expect(written.targets).toHaveLength(1);
+        });
+
+        it('should render a one-line summary', () => {
+            const report = makeReport();
+            const stat = createTargetStat();
+
+            stat.unitsTotal = 10;
+            stat.cached = 5;
+            stat.cacheMisses = 5;
+            stat.cacheEnabled = true;
+            stat.requests = 3;
+
+            report.addTarget('en', stat);
+            const summary = report.summary();
+
+            expect(summary).not.toContain('\n');
+            expect(summary).toContain('run success');
+            expect(summary).toContain('units: 10 (5 cached, 50% hit rate)');
+            expect(summary).toContain('requests: 3');
+            expect(summary).toContain('errors: 0');
+        });
+    });
+});

--- a/src/commands/translate/report.spec.ts
+++ b/src/commands/translate/report.spec.ts
@@ -7,8 +7,10 @@ import {
     RunReport,
     TRANSLATE_REPORT_SCHEMA_VERSION,
     createTargetStat,
+    reportError,
     scoreDistribution,
 } from './report';
+import {TranslateError} from './utils';
 
 function makeReport(path?: AbsolutePath) {
     return new RunReport({
@@ -33,6 +35,26 @@ describe('translate run report', () => {
             expect(distribution['90-99']).toBe(1);
             expect(distribution['100']).toBe(2);
             expect(distribution['50-59']).toBe(0);
+        });
+    });
+
+    describe('reportError', () => {
+        it('should take the code from a TranslateError', () => {
+            const entry = reportError(new TranslateError('boom', 'MY_CODE'), {
+                target: 'en',
+                path: 'ru/file.md',
+            });
+
+            expect(entry).toEqual({
+                target: 'en',
+                path: 'ru/file.md',
+                code: 'MY_CODE',
+                message: 'boom',
+            });
+        });
+
+        it('should fall back to UNKNOWN for other errors', () => {
+            expect(reportError(new Error('oops'))).toEqual({code: 'UNKNOWN', message: 'oops'});
         });
     });
 

--- a/src/commands/translate/report.ts
+++ b/src/commands/translate/report.ts
@@ -1,0 +1,363 @@
+import {mkdirSync, writeFileSync} from 'node:fs';
+import {dirname} from 'node:path';
+
+/**
+ * Version of the run report schema. Bump it on any breaking change of the
+ * report shape, so consumers (analytics pipelines, dashboards) can detect
+ * incompatible reports instead of silently misreading them.
+ */
+export const TRANSLATE_REPORT_SCHEMA_VERSION = 1;
+
+export type TranslateReportStatus = 'success' | 'partial' | 'failed';
+
+export type TranslateReportError = {
+    /** Target language the error occurred for, when known. */
+    target?: string;
+    /** Input-relative file path the error relates to, when known. */
+    path?: string;
+    /** Stable error code (TranslateError code) or UNKNOWN. */
+    code: string;
+    message: string;
+};
+
+export type TranslateReportJudge = {
+    model: string;
+    threshold: number;
+    /** Number of scored source/translation pairs. */
+    scored: number;
+    averageScore: number;
+    /** Pairs scored below the threshold. */
+    belowThreshold: number;
+    /** Pairs the judge failed to score (unparsable or failed batches). */
+    unscored: number;
+    /** Score histogram by decade: '0-9' ... '90-99' plus '100'. */
+    distribution: Record<string, number>;
+};
+
+export type TranslateReportCounters = {
+    files: {translated: number; failed: number; retried: number};
+    units: {
+        total: number;
+        translated: number;
+        fromCache: number;
+        untranslated: number;
+        oversized: number;
+    };
+    chars: {source: number; translated: number; request: number};
+    /** Token usage as reported by the provider; null when not reported. */
+    tokens: {input: number; output: number} | null;
+    requests: {total: number; fallback: number; retries: number};
+    cache: {enabled: boolean; hits: number; misses: number; hitRate: number | null};
+};
+
+export type TranslateReportTarget = TranslateReportCounters & {
+    language: string;
+    judge?: TranslateReportJudge;
+};
+
+export type TranslateRunReport = {
+    schemaVersion: number;
+    /** ISO 8601 start time of the CLI process. */
+    startedAt: string;
+    finishedAt: string;
+    durationMs: number;
+    status: TranslateReportStatus;
+    provider: string;
+    model?: string;
+    fallbackModel?: string;
+    /** True when at least one request was served by the fallback model. */
+    fallbackUsed: boolean;
+    dryRun: boolean;
+    sourceLanguage: string;
+    targetLanguages: string[];
+    files: {selected: number; skipped: number};
+    totals: TranslateReportCounters;
+    targets: TranslateReportTarget[];
+    errors: TranslateReportError[];
+};
+
+/**
+ * Mutable per-target counters incremented by providers at the points
+ * where the events already happen (request sent, cache hit, retry,
+ * fallback, file failed). Mapped into the report schema by RunReport.
+ */
+export type TargetStat = {
+    inputTokens: number;
+    outputTokens: number;
+    /** True when the provider returned token usage at least once. */
+    usageSeen: boolean;
+    requests: number;
+    /** Characters actually sent in translation requests. */
+    bytes: number;
+    /** Units served from the persistent cache (including seeds). */
+    cached: number;
+    /** Units the enabled cache did not cover. */
+    cacheMisses: number;
+    cacheEnabled: boolean;
+    /** Units returned by the model untranslated. */
+    untranslated: number;
+    fallbackRequests: number;
+    /** Extra request attempts after retryable errors. */
+    retries: number;
+    unitsTotal: number;
+    /** Units translated by the provider during this run. */
+    translatedUnits: number;
+    /** Units skipped as too big for a single request. */
+    oversized: number;
+    sourceChars: number;
+    translatedChars: number;
+    filesTranslated: number;
+    filesFailed: number;
+    filesRetried: number;
+};
+
+export function createTargetStat(): TargetStat {
+    return {
+        inputTokens: 0,
+        outputTokens: 0,
+        usageSeen: false,
+        requests: 0,
+        bytes: 0,
+        cached: 0,
+        cacheMisses: 0,
+        cacheEnabled: false,
+        untranslated: 0,
+        fallbackRequests: 0,
+        retries: 0,
+        unitsTotal: 0,
+        translatedUnits: 0,
+        oversized: 0,
+        sourceChars: 0,
+        translatedChars: 0,
+        filesTranslated: 0,
+        filesFailed: 0,
+        filesRetried: 0,
+    };
+}
+
+/** Builds the full score histogram: '0-9' ... '90-99' plus exact '100'. */
+export function scoreDistribution(scores: number[]): Record<string, number> {
+    const distribution: Record<string, number> = {};
+
+    for (let low = 0; low < 100; low += 10) {
+        distribution[`${low}-${low + 9}`] = 0;
+    }
+    distribution['100'] = 0;
+
+    for (const score of scores) {
+        const bucket =
+            score >= 100
+                ? '100'
+                : `${Math.floor(score / 10) * 10}-${Math.floor(score / 10) * 10 + 9}`;
+        distribution[bucket] += 1;
+    }
+
+    return distribution;
+}
+
+function round(value: number, digits: number): number {
+    const factor = Math.pow(10, digits);
+    return Math.round(value * factor) / factor;
+}
+
+function targetCounters(stat: TargetStat): TranslateReportCounters {
+    const lookups = stat.cached + stat.cacheMisses;
+
+    return {
+        files: {
+            translated: stat.filesTranslated,
+            failed: stat.filesFailed,
+            retried: stat.filesRetried,
+        },
+        units: {
+            total: stat.unitsTotal,
+            translated: stat.translatedUnits,
+            fromCache: stat.cached,
+            untranslated: stat.untranslated,
+            oversized: stat.oversized,
+        },
+        chars: {
+            source: stat.sourceChars,
+            translated: stat.translatedChars,
+            request: stat.bytes,
+        },
+        tokens: stat.usageSeen ? {input: stat.inputTokens, output: stat.outputTokens} : null,
+        requests: {
+            total: stat.requests,
+            fallback: stat.fallbackRequests,
+            retries: stat.retries,
+        },
+        cache: {
+            enabled: stat.cacheEnabled,
+            hits: stat.cached,
+            misses: stat.cacheMisses,
+            hitRate: stat.cacheEnabled && lookups > 0 ? round(stat.cached / lookups, 4) : null,
+        },
+    };
+}
+
+function sumCounters(targets: TranslateReportCounters[]): TranslateReportCounters {
+    const totals = targetCounters(createTargetStat());
+    const tokens = {input: 0, output: 0};
+    let usageSeen = false;
+    let cacheEnabled = false;
+    let hits = 0;
+    let misses = 0;
+
+    for (const target of targets) {
+        totals.files.translated += target.files.translated;
+        totals.files.failed += target.files.failed;
+        totals.files.retried += target.files.retried;
+        totals.units.total += target.units.total;
+        totals.units.translated += target.units.translated;
+        totals.units.fromCache += target.units.fromCache;
+        totals.units.untranslated += target.units.untranslated;
+        totals.units.oversized += target.units.oversized;
+        totals.chars.source += target.chars.source;
+        totals.chars.translated += target.chars.translated;
+        totals.chars.request += target.chars.request;
+        totals.requests.total += target.requests.total;
+        totals.requests.fallback += target.requests.fallback;
+        totals.requests.retries += target.requests.retries;
+
+        if (target.tokens) {
+            usageSeen = true;
+            tokens.input += target.tokens.input;
+            tokens.output += target.tokens.output;
+        }
+
+        cacheEnabled = cacheEnabled || target.cache.enabled;
+        hits += target.cache.hits;
+        misses += target.cache.misses;
+    }
+
+    totals.tokens = usageSeen ? tokens : null;
+    totals.cache = {
+        enabled: cacheEnabled,
+        hits,
+        misses,
+        hitRate: cacheEnabled && hits + misses > 0 ? round(hits / (hits + misses), 4) : null,
+    };
+
+    return totals;
+}
+
+type RunReportInfo = {
+    provider: string;
+    model?: string;
+    fallbackModel?: string;
+    dryRun: boolean;
+    sourceLanguage: string;
+    targetLanguages: string[];
+    /** Absolute path to write the report to; the report is not written without it. */
+    path?: AbsolutePath;
+};
+
+/**
+ * Collects per-run translation statistics and produces the machine-readable
+ * run report. Providers feed it with per-target counters and errors; the
+ * report is finalized once and optionally written to `info.path`.
+ */
+export class RunReport {
+    private readonly info: RunReportInfo;
+
+    private files = {selected: 0, skipped: 0};
+
+    private targets: TranslateReportTarget[] = [];
+
+    private errors: TranslateReportError[] = [];
+
+    private data: TranslateRunReport | null = null;
+
+    constructor(info: RunReportInfo) {
+        this.info = info;
+    }
+
+    setFiles(selected: number, skipped: number) {
+        this.files = {selected, skipped};
+    }
+
+    addError(error: TranslateReportError) {
+        this.errors.push(error);
+    }
+
+    addTarget(language: string, stat: TargetStat, judge?: TranslateReportJudge) {
+        this.targets.push({
+            language,
+            ...targetCounters(stat),
+            ...(judge ? {judge} : {}),
+        });
+    }
+
+    /**
+     * Computes the final report. Idempotent: the first call fixes the
+     * result. Status is `failed` when passed explicitly (fatal error),
+     * `partial` when the run completed with recorded errors, `success`
+     * otherwise.
+     */
+    finalize(status?: 'failed'): TranslateRunReport {
+        if (this.data) {
+            return this.data;
+        }
+
+        const now = Date.now();
+        const durationMs = Math.round(process.uptime() * 1000);
+        const totals = sumCounters(this.targets);
+
+        this.data = {
+            schemaVersion: TRANSLATE_REPORT_SCHEMA_VERSION,
+            startedAt: new Date(now - durationMs).toISOString(),
+            finishedAt: new Date(now).toISOString(),
+            durationMs,
+            status: status || (this.errors.length ? 'partial' : 'success'),
+            provider: this.info.provider,
+            ...(this.info.model ? {model: this.info.model} : {}),
+            ...(this.info.fallbackModel ? {fallbackModel: this.info.fallbackModel} : {}),
+            fallbackUsed: totals.requests.fallback > 0,
+            dryRun: this.info.dryRun,
+            sourceLanguage: this.info.sourceLanguage,
+            targetLanguages: this.info.targetLanguages,
+            files: this.files,
+            totals,
+            targets: this.targets,
+            errors: this.errors,
+        };
+
+        return this.data;
+    }
+
+    /** Writes the finalized report to the configured path. No-op without a path. */
+    write() {
+        if (!this.info.path || !this.data) {
+            return;
+        }
+
+        mkdirSync(dirname(this.info.path), {recursive: true});
+        writeFileSync(this.info.path, JSON.stringify(this.data, null, 2) + '\n');
+    }
+
+    /** One-line human-readable run summary for the log. */
+    summary(): string {
+        const data = this.finalize();
+        const {totals} = data;
+        const seconds = round(data.durationMs / 1000, 1);
+        const cached =
+            totals.cache.hitRate === null
+                ? `${totals.units.fromCache} cached`
+                : `${totals.units.fromCache} cached, ${round(totals.cache.hitRate * 100, 1)}% hit rate`;
+        const tokens = totals.tokens
+            ? `; tokens: ${totals.tokens.input} in / ${totals.tokens.output} out`
+            : '';
+
+        return (
+            `run ${data.status} in ${seconds}s; ` +
+            `files: ${totals.files.translated} translated, ${totals.files.failed} failed; ` +
+            `units: ${totals.units.total} (${cached}); ` +
+            `chars: ${totals.chars.source} in / ${totals.chars.translated} out` +
+            tokens +
+            `; requests: ${totals.requests.total}` +
+            ` (${totals.requests.fallback} fallback, ${totals.requests.retries} retries)` +
+            `; errors: ${this.errors.length}`
+        );
+    }
+}

--- a/src/commands/translate/report.ts
+++ b/src/commands/translate/report.ts
@@ -1,5 +1,9 @@
+import type {TranslateLogger} from './logger';
+
 import {mkdirSync, writeFileSync} from 'node:fs';
 import {dirname} from 'node:path';
+
+import {TranslateError} from './utils';
 
 /**
  * Version of the run report schema. Bump it on any breaking change of the
@@ -253,12 +257,52 @@ type RunReportInfo = {
     path?: AbsolutePath;
 };
 
+/** The slice of the resolved translate config the report is built from. */
+type RunReportConfig = {
+    provider: string;
+    dryRun: boolean;
+    source: {language: string};
+    target: {language: string}[];
+    report?: AbsolutePath;
+    model?: string;
+    fallbackModel?: string;
+};
+
+/** Builds a report error entry from a caught error. */
+export function reportError(
+    error: unknown,
+    info: {target?: string; path?: string} = {},
+): TranslateReportError {
+    return {
+        ...info,
+        code: error instanceof TranslateError ? error.code : 'UNKNOWN',
+        message: String((error as Error)?.message || error),
+    };
+}
+
 /**
  * Collects per-run translation statistics and produces the machine-readable
  * run report. Providers feed it with per-target counters and errors; the
  * report is finalized once and optionally written to `info.path`.
  */
 export class RunReport {
+    /** Creates the collector for a run: info from the resolved config, file counts from the planner. */
+    static start(config: RunReportConfig, selected: number, skipped: number): RunReport {
+        const report = new RunReport({
+            provider: config.provider,
+            model: config.model,
+            fallbackModel: config.fallbackModel,
+            dryRun: config.dryRun,
+            sourceLanguage: config.source.language,
+            targetLanguages: config.target.map((target) => target.language),
+            path: config.report,
+        });
+
+        report.setFiles(selected, skipped);
+
+        return report;
+    }
+
     private readonly info: RunReportInfo;
 
     private files = {selected: 0, skipped: 0};
@@ -334,6 +378,21 @@ export class RunReport {
 
         mkdirSync(dirname(this.info.path), {recursive: true});
         writeFileSync(this.info.path, JSON.stringify(this.data, null, 2) + '\n');
+    }
+
+    /**
+     * Finalizes the report, writes it when a path is configured and always
+     * logs the one-line run summary. Report IO failures must not fail the
+     * translation run.
+     */
+    close(logger: TranslateLogger, status?: 'failed') {
+        this.finalize(status);
+        try {
+            this.write();
+        } catch (error) {
+            logger.warn('report', `Unable to write the run report: ${(error as Error).message}`);
+        }
+        logger.stat(this.summary());
     }
 
     /** One-line human-readable run summary for the log. */


### PR DESCRIPTION
## Purpose

Adds usage statistics collection to `yfm translate`. By the end of a run the CLI can write a machine-readable JSON report with a stable, versioned schema: consumers (CI pipelines, analytics, dashboards) get run timings and status, provider and model, fallback usage, volume, cache efficiency, judge scores and errors without parsing logs.

- New `--report <path>` flag (or the `translate.report` config key). Disabled by default: no report file is written without it.
- A one-line run summary is always logged at the end of the run:

  ```
  INFO PROCESSED run success in 12.4s; files: 12 translated, 0 failed; units: 340 (154 cached, 45.3% hit rate); chars: 15200 in / 16900 out; tokens: 5200 in / 4800 out; requests: 18 (2 fallback, 3 retries); errors: 0
  ```

- Counters are collected at the points where the events already happen (request sent, cache lookup, retry, fallback, file failed); the translate pipeline itself is not restructured and behavior without the flag is unchanged.

## Report schema

The shape is a public contract, versioned via the `schemaVersion` field: it is bumped on any breaking change so consumers can detect incompatible reports instead of silently misreading them. TypeScript types are exported from the translate module: `TranslateRunReport`, `TranslateReportCounters`, `TranslateReportTarget`, `TranslateReportJudge`, `TranslateReportError`, plus the `TRANSLATE_REPORT_SCHEMA_VERSION` constant.

Top level: schema version, start time and duration, status (`success` / `partial` / `failed`), provider, model, fallback model and whether it was used, dry-run flag, source and target languages, selected/skipped file counts, per-target counters, aggregated totals and the error list.

Counters (per target and in totals):

- files: translated / failed / retried after transient errors;
- units (segments): total, translated this run, from cache, returned untranslated, oversized;
- chars: source, translated, actually sent in requests;
- tokens: input/output as reported by the provider, `null` when not reported, estimates in dry-run;
- requests: total, fallback, retries;
- cache: enabled, hits, misses, hit rate (seed cache hits included).

With `--judge` the target also carries judge stats: model, threshold, scored pairs, average score, count below threshold, unscored pairs and a score histogram with stable decade buckets.

Errors are recorded with target language, file path, stable error code and message. `partial` status means the run completed but some files failed; `failed` means the run aborted on a fatal error (the report is still written).

Full field-by-field reference: `docs/translate-run-report.md`.

## Example

```json
{
    "schemaVersion": 1,
    "startedAt": "2026-08-25T10:00:00.000Z",
    "finishedAt": "2026-08-25T10:00:12.400Z",
    "durationMs": 12400,
    "status": "success",
    "provider": "openai",
    "model": "gpt-4o-mini",
    "fallbackModel": "gpt-4o",
    "fallbackUsed": true,
    "dryRun": false,
    "sourceLanguage": "ru",
    "targetLanguages": ["en"],
    "files": {"selected": 12, "skipped": 3},
    "totals": {
        "files": {"translated": 12, "failed": 0, "retried": 1},
        "units": {"total": 340, "translated": 182, "fromCache": 154, "untranslated": 4, "oversized": 0},
        "chars": {"source": 15200, "translated": 16900, "request": 8300},
        "tokens": {"input": 5200, "output": 4800},
        "requests": {"total": 18, "fallback": 2, "retries": 3},
        "cache": {"enabled": true, "hits": 154, "misses": 186, "hitRate": 0.4529}
    },
    "targets": [
        {
            "language": "en",
            "files": {"translated": 12, "failed": 0, "retried": 1},
            "units": {"total": 340, "translated": 182, "fromCache": 154, "untranslated": 4, "oversized": 0},
            "chars": {"source": 15200, "translated": 16900, "request": 8300},
            "tokens": {"input": 5200, "output": 4800},
            "requests": {"total": 18, "fallback": 2, "retries": 3},
            "cache": {"enabled": true, "hits": 154, "misses": 186, "hitRate": 0.4529},
            "judge": {
                "model": "gpt-4o",
                "threshold": 70,
                "scored": 182,
                "averageScore": 91.4,
                "belowThreshold": 5,
                "unscored": 0,
                "distribution": {"0-9": 0, "10-19": 0, "20-29": 0, "30-39": 0, "40-49": 1, "50-59": 1, "60-69": 3, "70-79": 12, "80-89": 40, "90-99": 95, "100": 30}
            }
        }
    ],
    "errors": []
}
```

## Implementation notes

- `src/commands/translate/report.ts` - schema types, the `RunReport` collector and the shared `TargetStat` counters both providers fill.
- LLM providers fill all counters; the `yandex` (Yandex Translate) provider has no token usage, persistent cache or judge, so those fields are `null` / disabled / absent.
- The judge quality report (`translate-quality.<lang>.json`) is unchanged; the run report duplicates only its aggregate stats.
- Unit tests cover the collector mapping and an end-to-end run with a mocked LLM client that reproduces the report on disk.
