### PR TITLE
fix(tests): do not ship the translate eval e2e and corpus in the npm package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ If a module contains a `MODULE.md` file, it is considered part of the module's c
   - `fixtures/` — test fixtures
   - `mocks/` — test mocks
 
+**Packaged tests contract:** `tests/` and `vitest.integration.config.ts` are shipped in the npm package (see `files` in `package.json`). Downstream consumers run the integration suite from the packaged layout against their own binary via the `DIPLODOC_BINARY_PATH` env variable. Therefore specs under `tests/` must not depend on anything outside `tests/` and the built CLI - in particular not on `scripts/` or `src/`, which are not shipped. A spec that needs them must be excluded from the package with a `!`-pattern in `files` (see `tests/e2e/translate-eval.spec.ts`).
+
 ### CLI Commands
 
 1. **build** — main command for building documentation

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "build",
     "assets",
     "tests",
+    "!tests/e2e/translate-eval.spec.ts",
+    "!tests/eval",
     "vitest.integration.config.ts"
   ],
   "scripts": {


### PR DESCRIPTION
## Problem

The npm package ships `tests/` (so downstream consumers can run the integration suite against their own binary via `DIPLODOC_BINARY_PATH`), but not `scripts/` and `src/`. The eval harness e2e added in #2225 (`tests/e2e/translate-eval.spec.ts`) spawns `scripts/translate-eval.mjs`, which bundles `src/commands/translate/eval/cli.ts` on the fly. So for any consumer of the packaged tests the spec spawned a missing script, the child died with MODULE_NOT_FOUND, and the assertion failed with `expected '' to contain 'Verdict: PASS'`. This is what broke the internal cli release flow on 5.57.x.

## Fix

The spec simply should not be shipped: downstream it would only re-verify what this repo's CI already verified on the same commit, and the harness cannot run without the sources anyway. So:

- exclude `tests/e2e/translate-eval.spec.ts` and the `tests/eval` corpus from the package via `!`-patterns in `files`;
- the spec itself is unchanged and still runs in this repo's CI on every PR;
- the packaged tests contract (specs under `tests/` must not depend on `scripts/` or `src/`) is now written down in AGENTS.md so it does not get violated again.

Verified with `npm pack`: the tarball no longer contains the spec or the corpus, the rest of the e2e suite (including `translation.spec.ts`) is intact and collects cleanly from the packaged layout; the in-repo e2e passes.